### PR TITLE
fix: #22 Preserve tag order as in other SDKs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Next Release
 ------------
 * Upcoming features and fixes
+* Fixed issue #22: Preserve tag order as in other SDKs
 
 0.1.0 (2020-03-26)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ zip_safe = True
 install_requires =
     depinfo
     httpx
+    ordered-set
     pydantic
     python-dotenv
 python_requires = >=3.6

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -17,8 +17,9 @@
 
 
 from abc import ABC
-from typing import Dict, Iterable, List, Union
+from typing import Dict, Iterable, List, Set, Union
 
+from ordered_set import OrderedSet
 from pydantic import Field, validator
 
 from ..abstract_base import AbstractBase
@@ -47,10 +48,10 @@ class ModelItemIO(BaseModel, ABC):
     perspectives: List[PerspectiveIO] = Field(default=())
 
     @validator("tags", pre=True)
-    def split_tags(cls, tags: Union[str, List[str]]) -> List[str]:
+    def split_tags(cls, tags: Union[str, List[str], Set[str]]) -> List[str]:
         if isinstance(tags, str):
             return tags.split(",")
-        return tags
+        return list(tags)
 
     def dict(self, **kwargs) -> dict:
         """"""
@@ -84,7 +85,7 @@ class ModelItem(AbstractBase, ABC):
         """"""
         super().__init__(**kwargs)
         self.id = id
-        self.tags = set(tags)
+        self.tags = OrderedSet(tags)
         self.properties = dict(properties)
         self.perspectives = set(perspectives)
 

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -48,7 +48,7 @@ class ModelItemIO(BaseModel, ABC):
     perspectives: List[PerspectiveIO] = Field(default=())
 
     @validator("tags", pre=True)
-    def split_tags(cls, tags: Union[str, List[str], Set[str]]) -> List[str]:
+    def split_tags(cls, tags: Union[str, Iterable[str]]) -> List[str]:
         if isinstance(tags, str):
             return tags.split(",")
         return list(tags)

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -23,7 +23,8 @@ from structurizr.model.model_item import ModelItem
 
 
 @pytest.fixture(scope="function")
-def model() -> Model:
+def empty_model() -> Model:
+    """Provide an empty Model on demand for test cases to use."""
     return Model()
 
 
@@ -44,24 +45,30 @@ def test_model_item_init(attributes):
         assert getattr(model_item, attr) == expected
 
 
-def test_get_tags_when_there_are_no_tags(model: Model):
-    element = model.add_software_system(name="Name", description="Description")
+def test_default_element_tags_order(empty_model: Model):
+    """Test that the default tags get added in the right order."""
+    element = empty_model.add_software_system(name="Name", description="Description")
     assert list(element.tags) == ["Element", "Software System"]
 
 
-def test_get_tags_returns_the_list_of_tags_when_there_are_some_tags(model: Model):
-    # Based on the equivalent Java test, but also checks tag ordering is preserved
-    # See https://github.com/Midnighter/structurizr-python/issues/22
-    element = model.add_software_system(name="Name", description="Description")
-    element.tags.update(["tag3", "tag2", "tag1"])  # Deliberately unsorted
+def test_default_and_custom_tags(empty_model: Model):
+    """
+    Test that tags are in the order that they were added.
+
+    See https://github.com/Midnighter/structurizr-python/issues/22
+    """
+    element = empty_model.add_software_system(name="Name", description="Description")
+    element.tags.update(["tag3", "tag2", "tag1"])  # Deliberately not ascending
     assert list(element.tags) == ["Element", "Software System", "tag3", "tag2", "tag1"]
 
 
-def test_tag_order_is_preserved_to_and_from_io(model: Model):
-    element = model.add_software_system(name="Name", description="Description")
-    element.tags.update(["tag3", "tag2", "tag1"])  # Deliberately unsorted
+def test_tag_order_is_preserved_to_and_from_io(empty_model: Model):
+    """Test that when serializing via IO classes or back that tag ordering is preserved."""
+    element = empty_model.add_software_system(name="Name", description="Description")
+    element.tags.update(["tag3", "tag2", "tag1"])  # Deliberately not ascending
 
-    elementIO = SoftwareSystemIO.from_orm(element)
-    assert elementIO.tags == ["Element", "Software System", "tag3", "tag2", "tag1"]
-    element2 = SoftwareSystem.hydrate(elementIO, model)
+    element_io = SoftwareSystemIO.from_orm(element)
+    assert element_io.tags == ["Element", "Software System", "tag3", "tag2", "tag1"]
+    assert element_io.dict()["tags"] == "Element,Software System,tag3,tag2,tag1"
+    element2 = SoftwareSystem.hydrate(element_io, empty_model)
     assert list(element2.tags) == ["Element", "Software System", "tag3", "tag2", "tag1"]

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -21,9 +21,11 @@ import pytest
 from structurizr.model import Model, SoftwareSystem, SoftwareSystemIO
 from structurizr.model.model_item import ModelItem
 
+
 @pytest.fixture(scope="function")
 def model() -> Model:
     return Model()
+
 
 class ConcreteModelItem(ModelItem):
     """Implement a concrete `ModelItem` class for testing purposes."""
@@ -41,9 +43,11 @@ def test_model_item_init(attributes):
     for attr, expected in attributes.items():
         assert getattr(model_item, attr) == expected
 
+
 def test_get_tags_when_there_are_no_tags(model: Model):
     element = model.add_software_system(name="Name", description="Description")
     assert list(element.tags) == ["Element", "Software System"]
+
 
 def test_get_tags_returns_the_list_of_tags_when_there_are_some_tags(model: Model):
     # Based on the equivalent Java test, but also checks tag ordering is preserved
@@ -51,6 +55,7 @@ def test_get_tags_returns_the_list_of_tags_when_there_are_some_tags(model: Model
     element = model.add_software_system(name="Name", description="Description")
     element.tags.update(["tag3", "tag2", "tag1"])  # Deliberately unsorted
     assert list(element.tags) == ["Element", "Software System", "tag3", "tag2", "tag1"]
+
 
 def test_tag_order_is_preserved_to_and_from_io(model: Model):
     element = model.add_software_system(name="Name", description="Description")

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -46,7 +46,11 @@ def test_model_item_init(attributes):
 
 
 def test_default_element_tags_order(empty_model: Model):
-    """Test that the default tags get added in the right order."""
+    """
+    Test that the default tags get added in the right order.
+
+    Based on test_getTags_WhenThereAreNoTags() from the Java API.
+    """
     element = empty_model.add_software_system(name="Name", description="Description")
     assert list(element.tags) == ["Element", "Software System"]
 
@@ -54,6 +58,8 @@ def test_default_element_tags_order(empty_model: Model):
 def test_default_and_custom_tags(empty_model: Model):
     """
     Test that tags are in the order that they were added.
+
+    Based on test_getTags_ReturnsTheListOfTags_WhenThereAreSomeTags from the Java API.
 
     See https://github.com/Midnighter/structurizr-python/issues/22
     """

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ python =
 
 [testenv]
 deps =
-    ordered-set
     pytest
     pytest-cov
     pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ python =
 
 [testenv]
 deps =
+    ordered-set
     pytest
     pytest-cov
     pytest-mock


### PR DESCRIPTION
* [X] fix Midnighter/structurizr-python#22
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.