### PR TITLE
Issue 38: fix API change in httpx library which broke API calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ History
 
 Next Release
 ------------
-* Upcoming features and fixes
+* Fix: Change to httpx library API (#38)
 
 
 0.1.0 (2020-10-15)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ keywords =
 zip_safe = True
 install_requires =
     depinfo
-    httpx
+    httpx ~= 0.16
     importlib_metadata; python_version <'3.8'
     ordered-set
     pydantic

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -223,9 +223,7 @@ class StructurizrClient:
         request = self._client.build_request(
             "DELETE", self._lock_url, params=self._params
         )
-        request.headers.update(
-            self._add_headers(request)
-        )
+        request.headers.update(self._add_headers(request))
         response = self._client.send(request)
         response.raise_for_status()
         response = APIResponse.parse_raw(response.text)
@@ -254,7 +252,7 @@ class StructurizrClient:
 
         """
         method = request.method
-        url_path = request.url.raw_path.decode('ascii')
+        url_path = request.url.raw_path.decode("ascii")
         definition_md5 = self._md5(content)
         nonce = self._number_once()
         message_digest = self._message_digest(

--- a/tests/unit/api/test_structurizr_client.py
+++ b/tests/unit/api/test_structurizr_client.py
@@ -117,6 +117,17 @@ def test_archive_workspace(client, mocker):
     mocked_handle.write.assert_called_once_with('{"mock_key":"mock_value"}')
 
 
+def test_httpx_response_raw_path_behaviour():
+    """Make sure that `Response.raw_path` continues to do what we need.
+
+    As the httpx library is evolving rapidly, this is a defensive test to make sure
+    that `Response.raw_path` continues to behave as we need for StructurizrClient, in
+    particular not HTTP-escaping parameters.
+    """
+    request = Request(method="GET", url="http://someserver:8081/some/path?param=a+b")
+    assert request.url.raw_path.decode("ascii") == "/some/path?param=a+b"
+
+
 def test_add_headers_authentication(client: StructurizrClient, mocker):
     """Validate the headers are added correctly, including authentication."""
     mocker.patch.object(client, "_number_once", return_value="1529225966174")

--- a/tests/unit/api/test_structurizr_client.py
+++ b/tests/unit/api/test_structurizr_client.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from httpx import Request, Response
+from httpx import URL, Request, Response
 from pytest_mock import MockerFixture
 
 from structurizr.api.structurizr_client import StructurizrClient
@@ -122,10 +122,10 @@ def test_httpx_response_raw_path_behaviour():
 
     As the httpx library is evolving rapidly, this is a defensive test to make sure
     that `Response.raw_path` continues to behave as we need for StructurizrClient, in
-    particular not HTTP-escaping parameters.
+    particular not HTTP-escaping parameters, but still ASCII-encoding the URL.
     """
-    request = Request(method="GET", url="http://someserver:8081/some/path?param=a+b")
-    assert request.url.raw_path.decode("ascii") == "/some/path?param=a+b"
+    url = URL("http://example.com:8080/api/test?q=motörhead")
+    assert url.raw_path.decode("ascii") == "/api/test?q=mot%C3%B6rhead"
 
 
 def test_add_headers_authentication(client: StructurizrClient, mocker):

--- a/tests/unit/api/test_structurizr_client.py
+++ b/tests/unit/api/test_structurizr_client.py
@@ -114,24 +114,20 @@ def test_archive_workspace(client, mocker):
 
 def test_add_headers_authentication(client: StructurizrClient, mocker):
     """Validate the headers are added correctly, including authentication."""
-    mocker.patch.object(
-        client,
-        "_number_once",
-        return_value="1529225966174"
-    )
+    mocker.patch.object(client, "_number_once", return_value="1529225966174")
     request = client._client.build_request("GET", client._workspace_url)
     headers = client._add_headers(request)
-    assert headers['Nonce'] == "1529225966174"
-    assert headers['X-Authorization'] == (
-        '7f4e4edc-f61c-4ff2-97c9-ea4bc2a7c98c:'
-        'ZmJhNTVkMDM2NGEwN2I5YjRhMDgwZWNhMjA0ODIzZD'
-        'kyMTg3YzliMzVhMjBlNmM4ZjAxMDAwOGU4OGJlODEwMQ=='
+    assert headers["Nonce"] == "1529225966174"
+    assert headers["X-Authorization"] == (
+        "7f4e4edc-f61c-4ff2-97c9-ea4bc2a7c98c:"
+        "ZmJhNTVkMDM2NGEwN2I5YjRhMDgwZWNhMjA0ODIzZD"
+        "kyMTg3YzliMzVhMjBlNmM4ZjAxMDAwOGU4OGJlODEwMQ=="
     )
-    assert 'Content-MD5' not in headers
-    assert 'Content-Type' not in headers
+    assert "Content-MD5" not in headers
+    assert "Content-Type" not in headers
 
     # Check the additional headers needed for PUTs
     request = client._client.build_request("PUT", client._workspace_url)
     headers = client._add_headers(request, content="Hello", content_type="World")
-    assert headers['Content-MD5'] == 'OGIxYTk5NTNjNDYxMTI5NmE4MjdhYmY4YzQ3ODA0ZDc='
-    assert headers['Content-Type'] == 'World'
+    assert headers["Content-MD5"] == "OGIxYTk5NTNjNDYxMTI5NmE4MjdhYmY4YzQ3ODA0ZDc="
+    assert headers["Content-Type"] == "World"


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/38
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

`httpx.URL` class had its API changed in version 0.15 to change `full_path` to `raw_path`.  This PR updates `StructurizrClient` to work with this new httpx API.

--------------------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.