### PR TITLE
Issue 42: automatic addition of implied relationships

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ History
 
 Next Release
 ------------
+* Feat: Add implied relationships to entities (#42)
 
 0.1.1 (2020-10-19)
 ------------------

--- a/src/structurizr/model/element.py
+++ b/src/structurizr/model/element.py
@@ -100,7 +100,11 @@ class Element(ModelRefMixin, ModelItem, ABC):
         )
 
     def add_relationship(
-        self, relationship: Optional[Relationship] = None, **kwargs
+        self,
+        relationship: Optional[Relationship] = None,
+        *,
+        create_implied_relationships: bool = True,
+        **kwargs,
     ) -> Relationship:
         """Add a new relationship from this element to another.
 
@@ -119,7 +123,10 @@ class Element(ModelRefMixin, ModelItem, ABC):
                 f"Cannot add relationship {relationship} to element {self} that is not its source."
             )
         self.relationships.add(relationship)
-        self.get_model().add_relationship(relationship)
+        self.get_model().add_relationship(
+            relationship,
+            create_implied_relationships=create_implied_relationships
+        )
         return relationship
 
     @classmethod

--- a/src/structurizr/model/element.py
+++ b/src/structurizr/model/element.py
@@ -123,7 +123,7 @@ class Element(ModelRefMixin, ModelItem, ABC):
                 f"Cannot add relationship {relationship} to element {self} that is not its source."
             )
         self.relationships.add(relationship)
-        self.get_model().add_relationship(
+        self.model.add_relationship(
             relationship, create_implied_relationships=create_implied_relationships
         )
         return relationship

--- a/src/structurizr/model/element.py
+++ b/src/structurizr/model/element.py
@@ -124,8 +124,7 @@ class Element(ModelRefMixin, ModelItem, ABC):
             )
         self.relationships.add(relationship)
         self.get_model().add_relationship(
-            relationship,
-            create_implied_relationships=create_implied_relationships
+            relationship, create_implied_relationships=create_implied_relationships
         )
         return relationship
 

--- a/src/structurizr/model/implied_relationship_strategies.py
+++ b/src/structurizr/model/implied_relationship_strategies.py
@@ -1,0 +1,108 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Implement various strategies for adding implied relationships to the model.
+
+Implied relationship strategies are used to add relationships to parents when a
+relationship is added to their children.  For example, assuming systems A and B with
+child containers A1 and B1 respectively, then saying that A1 uses B1 implies that
+A also uses B (and A uses B1 and A1 uses B).  Each strategy is represented as a
+function that can be set on `Model.implied_relationship_strategy`, with the default
+being to do nothing.
+"""
+
+from itertools import product
+from typing import List
+
+from .element import Element
+from .relationship import Relationship
+from .software_system import SoftwareSystem
+
+
+def default_implied_relationship_strategy(relationship: Relationship):
+    """Don't create any implied relationships."""
+    pass
+
+
+def create_implied_relationships_unless_any_exist(relationship: Relationship):
+    """
+    Create implied relationships unless there is any existing.
+
+    This strategy creates implied relationships between all valid combinations of the
+    parent elements, unless any relationship already exists between them.
+    """
+    source = relationship.source
+    destination = relationship.destination
+    ancestor_pairs = product(_get_ancestors(source), _get_ancestors(destination))
+    for new_source, new_destination in ancestor_pairs:
+        if _implied_relationship_is_allowed(new_source, new_destination):
+            if not any(
+                r.destination is new_destination
+                for r in new_source.get_efferent_relationships()
+            ):
+                _clone_relationship(relationship, new_source, new_destination)
+
+
+def create_implied_relationships_unless_same_exists(relationship: Relationship):
+    """
+    Create implied relationships unless there is a existing one with the same description.
+
+    This strategy creates implied relationships between all valid combinations of the
+    parent elements, unless any relationship already exists between them which has the
+    same description as the original.
+    """
+    source = relationship.source
+    destination = relationship.destination
+    ancestor_pairs = product(_get_ancestors(source), _get_ancestors(destination))
+    for new_source, new_destination in ancestor_pairs:
+        if _implied_relationship_is_allowed(new_source, new_destination):
+            if not any(
+                r.destination is new_destination
+                and r.description == relationship.description
+                for r in new_source.get_efferent_relationships()
+            ):
+                _clone_relationship(relationship, new_source, new_destination)
+
+
+def _implied_relationship_is_allowed(source: Element, destination: Element):
+    return source not in _get_ancestors(
+        destination
+    ) and destination not in _get_ancestors(source)
+
+
+def _get_ancestors(element: Element, include_self=True) -> List[Element]:
+    """Get the ancestors of an element."""
+    result = []
+    current = element
+    while current is not None:
+        result.append(current)
+        current = None if isinstance(current, SoftwareSystem) else current.parent
+    if not include_self:
+        result.remove(element)
+    return result
+
+
+def _clone_relationship(
+    relationship: Relationship, new_source: Element, new_destination: Element
+) -> Relationship:
+    print(f"{new_source.name}->{new_destination.name}")
+    return new_source.add_relationship(
+        destination=new_destination,
+        description=relationship.description,
+        technology=relationship.technology,
+        interaction_style=relationship.interaction_style,
+        tags=relationship.tags,
+        properties=relationship.properties,
+        create_implied_relationships=False,
+    )

--- a/src/structurizr/model/implied_relationship_strategies.py
+++ b/src/structurizr/model/implied_relationship_strategies.py
@@ -56,7 +56,7 @@ def create_implied_relationships_unless_any_exist(relationship: Relationship):
 
 def create_implied_relationships_unless_same_exists(relationship: Relationship):
     """
-    Create implied relationships unless there is a existing one with the same description.
+    Create implied relationships unless there is one with the same description.
 
     This strategy creates implied relationships between all valid combinations of the
     parent elements, unless any relationship already exists between them which has the

--- a/src/structurizr/model/implied_relationship_strategies.py
+++ b/src/structurizr/model/implied_relationship_strategies.py
@@ -81,15 +81,13 @@ def _implied_relationship_is_allowed(source: Element, destination: Element):
     ) and destination not in _get_ancestors(source)
 
 
-def _get_ancestors(element: Element, include_self=True) -> List[Element]:
+def _get_ancestors(element: Element) -> List[Element]:
     """Get the ancestors of an element."""
     result = []
     current = element
     while current is not None:
         result.append(current)
         current = None if isinstance(current, SoftwareSystem) else current.parent
-    if not include_self:
-        result.remove(element)
     return result
 
 

--- a/src/structurizr/model/implied_relationship_strategies.py
+++ b/src/structurizr/model/implied_relationship_strategies.py
@@ -30,7 +30,7 @@ from .relationship import Relationship
 from .software_system import SoftwareSystem
 
 
-def default_implied_relationship_strategy(relationship: Relationship):
+def ignore_implied_relationship_strategy(relationship: Relationship):
     """Don't create any implied relationships."""
     pass
 

--- a/src/structurizr/model/implied_relationship_strategies.py
+++ b/src/structurizr/model/implied_relationship_strategies.py
@@ -76,13 +76,15 @@ def create_implied_relationships_unless_same_exists(relationship: Relationship):
 
 
 def _implied_relationship_is_allowed(source: Element, destination: Element):
-    return source not in _get_ancestors(
-        destination
-    ) and destination not in _get_ancestors(source)
+    if source is destination:
+        return False
+    elif source in _get_ancestors(destination) or destination in _get_ancestors(source):
+        return False
+    return True
 
 
 def _get_ancestors(element: Element) -> List[Element]:
-    """Get the ancestors of an element."""
+    """Get the ancestors of an element, including itself."""
     result = []
     current = element
     while current is not None:

--- a/src/structurizr/model/model.py
+++ b/src/structurizr/model/model.py
@@ -29,6 +29,9 @@ from .container import Container
 from .container_instance import ContainerInstance
 from .element import Element
 from .enterprise import Enterprise, EnterpriseIO
+from .implied_relationship_strategies import (
+    ignore_implied_relationship_strategy as ignore_implied,
+)
 from .person import Person, PersonIO
 from .relationship import Relationship
 from .sequential_integer_id_generator import SequentialIntegerIDGenerator
@@ -96,7 +99,7 @@ class Model(AbstractBase):
         people: Optional[Iterable[Person]] = (),
         software_systems: Iterable[SoftwareSystem] = (),
         deployment_nodes: Iterable[DeploymentNode] = (),
-        implied_relationship_strategy: Optional[Callable[[Relationship], None]] = None,
+        implied_relationship_strategy: Callable[[Relationship], None] = ignore_implied,
         **kwargs,
     ) -> None:
         """
@@ -397,10 +400,7 @@ class Model(AbstractBase):
         )
         self._add_relationship_to_internal_structures(relationship)
 
-        if (
-            create_implied_relationships
-            and self.implied_relationship_strategy is not None
-        ):
+        if create_implied_relationships:
             self.implied_relationship_strategy(relationship)
         return True
 

--- a/src/structurizr/model/relationship.py
+++ b/src/structurizr/model/relationship.py
@@ -117,6 +117,15 @@ class Relationship(ModelItem):
 
         return self._destination_id
 
+    @property
+    def interaction_style(self) -> str:
+        """Return the interaction style of the relationship based on its tags."""
+        return (
+            InteractionStyle.Synchronous
+            if Tags.SYNCHRONOUS in self.tags
+            else InteractionStyle.Asynchronous
+        )
+
     @classmethod
     def hydrate(cls, relationship_io: RelationshipIO) -> "Relationship":
         """"""

--- a/src/structurizr/model/relationship.py
+++ b/src/structurizr/model/relationship.py
@@ -105,6 +105,7 @@ class Relationship(ModelItem):
 
     @property
     def source_id(self) -> str:
+        """Return the ID of the source element of this relationship."""
         if self.source is not None:
             return self.source.id
 
@@ -112,6 +113,7 @@ class Relationship(ModelItem):
 
     @property
     def destination_id(self) -> str:
+        """Return the ID of the destination element of this relationship."""
         if self.destination is not None:
             return self.destination.id
 
@@ -128,7 +130,7 @@ class Relationship(ModelItem):
 
     @classmethod
     def hydrate(cls, relationship_io: RelationshipIO) -> "Relationship":
-        """"""
+        """Hydrate a new instance of Relationship from its IO."""
         return cls(
             id=relationship_io.id,
             tags=relationship_io.tags,

--- a/tests/integration/test_implied_relationship_strategies.py
+++ b/tests/integration/test_implied_relationship_strategies.py
@@ -16,9 +16,13 @@ import pytest
 
 from structurizr.model import InteractionStyle, Model
 from structurizr.model.implied_relationship_strategies import (
-    create_implied_relationships_unless_any_exist,
-    create_implied_relationships_unless_same_exists,
-    ignore_implied_relationship_strategy,
+    create_implied_relationships_unless_any_exist as create_unless_any_exist,
+)
+from structurizr.model.implied_relationship_strategies import (
+    create_implied_relationships_unless_same_exists as create_unless_same_exists,
+)
+from structurizr.model.implied_relationship_strategies import (
+    ignore_implied_relationship_strategy as ignore,
 )
 
 
@@ -42,7 +46,7 @@ def test_by_default_model_doesnt_create_implied_relationships():
 
 def test_ignore_implied_relationship_strategy():
     """Check that by default no implied relationships are added."""
-    model = Model(implied_relationship_strategy=ignore_implied_relationship_strategy)
+    model = Model(implied_relationship_strategy=ignore)
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
     system2 = model.add_software_system(name="system2")
@@ -58,8 +62,7 @@ def test_ignore_implied_relationship_strategy():
 
 def test_create_implied_relationships_unless_any_exist():
     """Check logic of create_implied_relationships_unless_any_exist."""
-    model = Model()
-    model.implied_relationship_strategy = create_implied_relationships_unless_any_exist
+    model = Model(implied_relationship_strategy=create_unless_any_exist)
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
     component1 = container1.add_component(name="component1", description="test")
@@ -91,10 +94,7 @@ def test_create_implied_relationships_unless_any_exist():
 
 def test_create_implied_relationships_unless_same_exists():
     """Check logic of create_implied_relationships_unless_same_exists."""
-    model = Model()
-    model.implied_relationship_strategy = (
-        create_implied_relationships_unless_same_exists
-    )
+    model = Model(implied_relationship_strategy=create_unless_same_exists)
 
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
@@ -110,8 +110,7 @@ def test_create_implied_relationships_unless_same_exists():
 
 def test_suppressing_implied_relationships():
     """Ensure you can explicitly suppress the current strategy."""
-    model = Model()
-    model.implied_relationship_strategy = create_implied_relationships_unless_any_exist
+    model = Model(implied_relationship_strategy=create_unless_any_exist)
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
     system2 = model.add_software_system(name="system2")
@@ -128,8 +127,8 @@ def test_suppressing_implied_relationships():
 @pytest.mark.parametrize(
     "strategy",
     [
-        create_implied_relationships_unless_any_exist,
-        create_implied_relationships_unless_same_exists,
+        create_unless_any_exist,
+        create_unless_same_exists,
     ],
 )
 def test_self_references_are_not_implied(strategy):
@@ -146,8 +145,7 @@ def test_self_references_are_not_implied(strategy):
 
 def test_cloning_to_implied_relationship_copies_attributes_across():
     """Make sure that attributes carry over to implied relationships."""
-    model = Model()
-    model.implied_relationship_strategy = create_implied_relationships_unless_any_exist
+    model = Model(implied_relationship_strategy=create_unless_any_exist)
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
     system2 = model.add_software_system(name="system2")

--- a/tests/integration/test_implied_relationship_strategies.py
+++ b/tests/integration/test_implied_relationship_strategies.py
@@ -26,22 +26,10 @@ from structurizr.model.implied_relationship_strategies import (
 )
 
 
-def test_by_default_model_doesnt_create_implied_relationships():
+def test_by_default_model_ignores_implied_relationships():
     """Check if not set on Model, no implied relationships are added."""
     model = Model()
-    assert model.implied_relationship_strategy is None
-
-    system1 = model.add_software_system(name="system1")
-    container1 = system1.add_container(name="container1", description="test")
-    system2 = model.add_software_system(name="system2")
-    container2 = system2.add_container(name="container2", description="test")
-
-    rel = container1.uses(container2, "Uses")
-
-    assert len(list(container1.get_relationships())) == 1
-    assert len(list(system1.get_relationships())) == 0
-    assert set(container1.get_relationships()) == {rel}
-    assert set(system1.get_relationships()) == set()
+    assert model.implied_relationship_strategy is ignore
 
 
 def test_ignore_implied_relationship_strategy():

--- a/tests/integration/test_implied_relationship_strategies.py
+++ b/tests/integration/test_implied_relationship_strategies.py
@@ -18,7 +18,7 @@ from structurizr.model import InteractionStyle, Model
 from structurizr.model.implied_relationship_strategies import (
     create_implied_relationships_unless_any_exist,
     create_implied_relationships_unless_same_exists,
-    default_implied_relationship_strategy,
+    ignore_implied_relationship_strategy,
 )
 
 
@@ -40,9 +40,9 @@ def test_by_default_model_doesnt_create_implied_relationships():
     assert set(system1.get_relationships()) == set()
 
 
-def test_default_implied_relationship_strategy():
+def test_ignore_implied_relationship_strategy():
     """Check that by default no implied relationships are added."""
-    model = Model(implied_relationship_strategy=default_implied_relationship_strategy)
+    model = Model(implied_relationship_strategy=ignore_implied_relationship_strategy)
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
     system2 = model.add_software_system(name="system2")
@@ -95,6 +95,7 @@ def test_create_implied_relationships_unless_same_exists():
     model.implied_relationship_strategy = (
         create_implied_relationships_unless_same_exists
     )
+
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
     system2 = model.add_software_system(name="system2")
@@ -133,8 +134,7 @@ def test_suppressing_implied_relationships():
 )
 def test_self_references_are_not_implied(strategy):
     """Ensure references from an element to itself don't get implied to parents."""
-    model = Model()
-    model.implied_relationship_strategy = strategy
+    model = Model(implied_relationship_strategy=strategy)
     system1 = model.add_software_system(name="system1")
     container1 = system1.add_container(name="container1", description="test")
 

--- a/tests/integration/test_implied_relationship_strategies.py
+++ b/tests/integration/test_implied_relationship_strategies.py
@@ -1,0 +1,148 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the various strategies for adding implied relationships."""
+
+from structurizr.model import InteractionStyle, Model
+from structurizr.model.implied_relationship_strategies import (
+    create_implied_relationships_unless_any_exist,
+    create_implied_relationships_unless_same_exists,
+    default_implied_relationship_strategy,
+)
+
+
+def test_by_default_model_doesnt_create_implied_relationships():
+    """Check if not set on Model, no implied relationships are added."""
+    model = Model()
+    assert model.implied_relationship_strategy is None
+
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+    system2 = model.add_software_system(name="system2")
+    container2 = system2.add_container(name="container2", description="test")
+
+    rel = container1.uses(container2, "Uses")
+
+    assert len(list(container1.get_relationships())) == 1
+    assert len(list(system1.get_relationships())) == 0
+    assert set(container1.get_relationships()) == {rel}
+    assert set(system1.get_relationships()) == set()
+
+
+def test_default_implied_relationship_strategy():
+    """Check that by default no implied relationships are added."""
+    model = Model(implied_relationship_strategy=default_implied_relationship_strategy)
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+    system2 = model.add_software_system(name="system2")
+    container2 = system2.add_container(name="container2", description="test")
+
+    rel = container1.uses(container2, "Uses")
+
+    assert len(list(container1.get_relationships())) == 1
+    assert len(list(system1.get_relationships())) == 0
+    assert set(container1.get_relationships()) == {rel}
+    assert set(system1.get_relationships()) == set()
+
+
+def test_create_implied_relationships_unless_any_exist():
+    """Check logic of create_implied_relationships_unless_any_exist."""
+    model = Model()
+    model.implied_relationship_strategy = create_implied_relationships_unless_any_exist
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+    component1 = container1.add_component(name="component1", description="test")
+    system2 = model.add_software_system(name="system2")
+    container2 = system2.add_container(name="container2", description="test")
+    component2 = container2.add_component(name="component2", description="test")
+
+    component1.uses(component2, "Uses")
+
+    # We should now have every *1 element related to every *2 element
+    assert len(list(component1.get_relationships())) == 3
+    assert len(list(container1.get_relationships())) == 3
+    assert len(list(system1.get_relationships())) == 3
+    assert any(rel.destination is component2 for rel in component1.get_relationships())
+    assert any(rel.destination is container2 for rel in component1.get_relationships())
+    assert any(rel.destination is system2 for rel in component1.get_relationships())
+    assert any(rel.destination is component2 for rel in container1.get_relationships())
+    assert any(rel.destination is container2 for rel in container1.get_relationships())
+    assert any(rel.destination is system2 for rel in container1.get_relationships())
+    assert any(rel.destination is component2 for rel in system1.get_relationships())
+    assert any(rel.destination is container2 for rel in system1.get_relationships())
+    assert any(rel.destination is system2 for rel in system1.get_relationships())
+
+    # Now add another relationship, which shouldn't copy upwards as some already exist
+    container1.uses(container2, "Uses differently")
+    assert len(list(container1.get_relationships())) == 4  # 3 from before plus new one
+    assert len(list(system1.get_relationships())) == 3  # Same as before
+
+
+def test_create_implied_relationships_unless_same_exists():
+    """Check logic of create_implied_relationships_unless_same_exists."""
+    model = Model()
+    model.implied_relationship_strategy = (
+        create_implied_relationships_unless_same_exists
+    )
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+    system2 = model.add_software_system(name="system2")
+
+    system1.uses(system2, "Reads from")
+    assert len(list(system1.get_relationships())) == 1
+    container1.uses(system2, "Reads from")
+    assert len(list(system1.get_relationships())) == 1
+    container1.uses(system2, "Writes to")
+    assert len(list(system1.get_relationships())) == 2
+
+
+def test_suppressing_implied_relationships():
+    """Ensure you can explicitly suppress the current strategy."""
+    model = Model()
+    model.implied_relationship_strategy = create_implied_relationships_unless_any_exist
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+    system2 = model.add_software_system(name="system2")
+    container2 = system2.add_container(name="container2", description="test")
+
+    rel = container1.uses(container2, "Uses", create_implied_relationships=False)
+
+    assert len(list(container1.get_relationships())) == 1
+    assert len(list(system1.get_relationships())) == 0
+    assert set(container1.get_relationships()) == {rel}
+    assert set(system1.get_relationships()) == set()
+
+
+def test_cloning_to_implied_relationship_copies_attributes_across():
+    """Make sure that attributes carry over to implied relationships."""
+    model = Model()
+    model.implied_relationship_strategy = create_implied_relationships_unless_any_exist
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+    system2 = model.add_software_system(name="system2")
+    container2 = system2.add_container(name="container2", description="test")
+
+    rel = container1.uses(
+        container2,
+        "Uses",
+        technology="tech1",
+        interaction_style=InteractionStyle.Asynchronous,
+        tags="tag1,tag2",
+        properties={"prop1": "val1"},
+    )
+
+    new_rel = next(system1.get_relationships())
+
+    assert new_rel.description == "Uses"
+    assert new_rel.technology == "tech1"
+    assert new_rel.tags == rel.tags
+    assert new_rel.properties == rel.properties

--- a/tests/integration/test_implied_relationship_strategies.py
+++ b/tests/integration/test_implied_relationship_strategies.py
@@ -12,6 +12,8 @@
 
 """Test the various strategies for adding implied relationships."""
 
+import pytest
+
 from structurizr.model import InteractionStyle, Model
 from structurizr.model.implied_relationship_strategies import (
     create_implied_relationships_unless_any_exist,
@@ -120,6 +122,26 @@ def test_suppressing_implied_relationships():
     assert len(list(system1.get_relationships())) == 0
     assert set(container1.get_relationships()) == {rel}
     assert set(system1.get_relationships()) == set()
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        create_implied_relationships_unless_any_exist,
+        create_implied_relationships_unless_same_exists,
+    ],
+)
+def test_self_references_are_not_implied(strategy):
+    """Ensure references from an element to itself don't get implied to parents."""
+    model = Model()
+    model.implied_relationship_strategy = strategy
+    system1 = model.add_software_system(name="system1")
+    container1 = system1.add_container(name="container1", description="test")
+
+    container1.uses(container1, "Uses")
+
+    assert len(list(container1.get_relationships())) == 1
+    assert len(list(system1.get_relationships())) == 0
 
 
 def test_cloning_to_implied_relationship_copies_attributes_across():

--- a/tests/unit/model/test_element.py
+++ b/tests/unit/model/test_element.py
@@ -30,7 +30,7 @@ class ConcreteElement(Element):
 class MockModel:
     """Implement a mock model for reference testing."""
 
-    def add_relationship(self, relationship):
+    def add_relationship(self, relationship, create_implied_relationships):
         """Provide mock implementation."""
         return relationship
 


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/42
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Support the ability to automatically create implied relationships on ancestors when a relationship is added to a source/destination element.  Multiple strategies supported, consistent with the Java implementation, and the desired strategy can be set via `Model.implied_relationship_strategy`.

-------------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.