### PR TITLE
Add loads(), dump() and dumps() to Workspace for import/export.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Next Release
 ------------
 * Feat: Add implied relationships to entities (#42)
+* Feat: Add ``dump()``, ``dumps()`` and ``loads()`` methods to ``Workspace`` (#48)
 
 0.1.1 (2020-10-19)
 ------------------

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -142,7 +142,7 @@ class StructurizrClient:
             )
         logger.debug(response.text)
         self._archive_workspace(response.text)
-        return Workspace.hydrate(WorkspaceIO.parse_raw(response.text))
+        return Workspace.loads(response.text)
 
     def put_workspace(self, workspace: Workspace) -> None:
         """

--- a/src/structurizr/workspace.py
+++ b/src/structurizr/workspace.py
@@ -231,7 +231,7 @@ class Workspace(AbstractBase):
             kwargs: other arguments to pass through to `json.dumps()`.
         """
         filename = Path(filename)
-        with gzip.open(filename, "wt") if zip else open(filename, "wt") as handle:
+        with gzip.open(filename, "wt") if zip else filename.open("wt") as handle:
             handle.write(self.dumps(indent=indent, **kwargs))
 
     def dumps(self, indent: Optional[int] = None, **kwargs):

--- a/src/structurizr/workspace.py
+++ b/src/structurizr/workspace.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 from pydantic import Field
+from pydantic.types import StrBytes
 
 from .abstract_base import AbstractBase
 from .base_model import BaseModel
@@ -207,9 +208,9 @@ class Workspace(AbstractBase):
                 return cls.loads(handle.read())
 
     @classmethod
-    def loads(cls, json_string: str) -> "Workspace":
-        """Load a workspace from a JSON string."""
-        ws_io = WorkspaceIO.parse_raw(json_string)
+    def loads(cls, json: StrBytes) -> "Workspace":
+        """Load a workspace from a JSON string or bytes."""
+        ws_io = WorkspaceIO.parse_raw(json)
         return cls.hydrate(ws_io)
 
     def dump(

--- a/src/structurizr/workspace.py
+++ b/src/structurizr/workspace.py
@@ -196,7 +196,7 @@ class Workspace(AbstractBase):
 
     @classmethod
     def load(cls, filename: Union[str, Path]) -> "Workspace":
-        """Load a workspace from a file (which may optionally be gzipped)."""
+        """Load a workspace from a JSON file (which may optionally be gzipped)."""
         filename = Path(filename)
         try:
             with gzip.open(filename, "rt") as handle:
@@ -217,20 +217,25 @@ class Workspace(AbstractBase):
         self,
         filename: Union[str, Path],
         *,
-        zip: bool = False,
+        zip: Optional[bool] = None,
         indent: Optional[int] = None,
         **kwargs
     ):
         """
-        Save a workspace to a file, optionally zipped.
+        Save a workspace as JSON to a file, optionally gzipped.
+
+        By default, filenames ending with `.gz` will be zipped and anything else won't,
+        however this can be overridden by explicitly passing the `zip` argument.
 
         Arguments:
-            filename (str/Path): filename to write to.
-            zip (bool): if true then contents will be zipped with GZip.
-            indent (int): if specified then pretty-print the JSON with given indent.
+            filename: filename to write to.
+            zip: if specified then controls whether the contents are gzipped.
+            indent: if specified then pretty-print the JSON with given indent.
             kwargs: other arguments to pass through to `json.dumps()`.
         """
         filename = Path(filename)
+        if zip is None:
+            zip = str(filename).endswith(".gz")
         with gzip.open(filename, "wt") if zip else filename.open("wt") as handle:
             handle.write(self.dumps(indent=indent, **kwargs))
 

--- a/tests/integration/test_workspace_io.py
+++ b/tests/integration/test_workspace_io.py
@@ -136,12 +136,28 @@ def test_save_and_load_workspace_to_gzipped_file(monkeypatch, tmp_path: Path):
 
     filepath = tmp_path / "test_workspace.json.gz"
 
-    workspace.dump(filepath, zip=True)
+    workspace.dump(filepath)
     workspace2 = Workspace.load(filepath)
 
     expected = WorkspaceIO.from_orm(workspace)
     actual = WorkspaceIO.from_orm(workspace2)
     assert json.loads(actual.json()) == json.loads(expected.json())
+
+
+def test_workspace_overridding_zip_flag(monkeypatch, tmp_path: Path):
+    """Test that default zipping can be overridden explicitly."""
+    monkeypatch.syspath_prepend(EXAMPLES)
+    example = import_module("getting_started")
+    workspace = example.main()
+
+    filepath = tmp_path / "test_workspace.json.gz"
+
+    workspace.dump(filepath, zip=False)
+    contents = filepath.read_text()
+    assert "My software system" in contents
+
+    # Make sure can be loaded even though its not zipped and ends with .gz
+    Workspace.load(filepath)
 
 
 def test_load_unknown_file_raises_file_not_found():

--- a/tests/integration/test_workspace_io.py
+++ b/tests/integration/test_workspace_io.py
@@ -85,3 +85,55 @@ def test_serialize_workspace(example, filename, monkeypatch):
     # TODO (Midnighter): This should be equivalent to the above. Why is it not?
     #  Is `.json` not using the same default arguments as `.dict`?
     # assert actual.dict() == expected.dict()
+
+
+def test_save_and_load_workspace_to_string(monkeypatch):
+    """Test saving as a JSON string and reloading."""
+    monkeypatch.syspath_prepend(EXAMPLES)
+    example = import_module("getting_started")
+    workspace = example.main()
+
+    json_string: str = workspace.dumps(indent=2)
+    workspace2 = Workspace.loads(json_string)
+
+    expected = WorkspaceIO.from_orm(workspace)
+    actual = WorkspaceIO.from_orm(workspace2)
+    assert json.loads(actual.json()) == json.loads(expected.json())
+
+
+def test_save_and_load_workspace_to_file(monkeypatch, tmp_path: Path):
+    """Test saving as a JSON file and reloading."""
+    monkeypatch.syspath_prepend(EXAMPLES)
+    example = import_module("getting_started")
+    workspace = example.main()
+
+    filepath = tmp_path / "test_workspace.json"
+
+    workspace.dump(filepath, indent=2)
+    workspace2 = Workspace.load(filepath)
+
+    expected = WorkspaceIO.from_orm(workspace)
+    actual = WorkspaceIO.from_orm(workspace2)
+    assert json.loads(actual.json()) == json.loads(expected.json())
+
+
+def test_save_and_load_workspace_to_zipped_file(monkeypatch, tmp_path: Path):
+    """Test saving as a zipped JSON file and reloading."""
+    monkeypatch.syspath_prepend(EXAMPLES)
+    example = import_module("getting_started")
+    workspace = example.main()
+
+    filepath = tmp_path / "test_workspace.json.gz"
+
+    workspace.dump(filepath, zip=True)
+    workspace2 = Workspace.load(filepath)
+
+    expected = WorkspaceIO.from_orm(workspace)
+    actual = WorkspaceIO.from_orm(workspace2)
+    assert json.loads(actual.json()) == json.loads(expected.json())
+
+
+def test_load_unknown_file_raises_file_not_found():
+    """Test that attempting to load a non-existent file raises FileNotFound."""
+    with pytest.raises(FileNotFoundError):
+        Workspace.load("foobar.json")

--- a/tests/integration/test_workspace_io.py
+++ b/tests/integration/test_workspace_io.py
@@ -104,7 +104,7 @@ def test_save_and_load_workspace_to_string(monkeypatch):
 def test_load_workspace_from_bytes(monkeypatch):
     """Test loading from bytes rather than string."""
     path = DEFINITIONS / "GettingStarted.json"
-    with open(path, mode='rb') as file:
+    with open(path, mode="rb") as file:
         binary_content = file.read()
 
     workspace = Workspace.loads(binary_content)

--- a/tests/integration/test_workspace_io.py
+++ b/tests/integration/test_workspace_io.py
@@ -101,6 +101,17 @@ def test_save_and_load_workspace_to_string(monkeypatch):
     assert json.loads(actual.json()) == json.loads(expected.json())
 
 
+def test_load_workspace_from_bytes(monkeypatch):
+    """Test loading from bytes rather than string."""
+    path = DEFINITIONS / "GettingStarted.json"
+    with open(path, mode='rb') as file:
+        binary_content = file.read()
+
+    workspace = Workspace.loads(binary_content)
+
+    assert workspace.model.software_systems != set()
+
+
 def test_save_and_load_workspace_to_file(monkeypatch, tmp_path: Path):
     """Test saving as a JSON file and reloading."""
     monkeypatch.syspath_prepend(EXAMPLES)
@@ -117,7 +128,7 @@ def test_save_and_load_workspace_to_file(monkeypatch, tmp_path: Path):
     assert json.loads(actual.json()) == json.loads(expected.json())
 
 
-def test_save_and_load_workspace_to_zipped_file(monkeypatch, tmp_path: Path):
+def test_save_and_load_workspace_to_gzipped_file(monkeypatch, tmp_path: Path):
     """Test saving as a zipped JSON file and reloading."""
     monkeypatch.syspath_prepend(EXAMPLES)
     example = import_module("getting_started")


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/48
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Add `dump()`, `dumps()` and `loads()` to `Workspace` to make it easier to work with import/export outside of Structurizr.  Opted not to go for an example as @mrchrisadams is looking to do this in `readme.rst`, which is probably better.

------------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS