### PR TITLE
Better error message on bogus constructor param to elements and other model items

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Next Release
 ------------
 * Feat: Add implied relationships to entities (#42)
+* Fix: Better error on bad ModelItem constructor argument (#50)
 
 0.1.1 (2020-10-19)
 ------------------

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -87,11 +87,15 @@ class ModelItem(AbstractBase, ABC):
             type_name = type(self).__name__
             args = [f"'{key}'" for key in kwargs.keys()]
             if len(args) == 1:
-                raise TypeError(f"{type_name}.__init__() got an unexpected "
-                                f"keyword argument {args[0]}")
+                raise TypeError(
+                    f"{type_name}.__init__() got an unexpected "
+                    f"keyword argument {args[0]}"
+                )
             else:
-                raise TypeError(f"{type_name}.__init__() got unexpected "
-                                f"keyword arguments {', '.join(args)}")
+                raise TypeError(
+                    f"{type_name}.__init__() got unexpected "
+                    f"keyword arguments {', '.join(args)}"
+                )
 
         super().__init__()
         self.id = id

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -83,7 +83,17 @@ class ModelItem(AbstractBase, ABC):
         **kwargs,
     ):
         """"""
-        super().__init__(**kwargs)
+        if len(kwargs) > 0:
+            type_name = type(self).__name__
+            args = [f"'{key}'" for key in kwargs.keys()]
+            if len(args) == 1:
+                raise TypeError(f"{type_name}.__init__() got an unexpected "
+                                f"keyword argument {args[0]}")
+            else:
+                raise TypeError(f"{type_name}.__init__() got unexpected "
+                                f"keyword arguments {', '.join(args)}")
+
+        super().__init__()
         self.id = id
         self.tags = OrderedSet(tags)
         self.properties = dict(properties)

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -52,14 +52,15 @@ def test_handling_of_bogus_init_params():
     See https://github.com/Midnighter/structurizr-python/issues/50.
     """
     with pytest.raises(
-        TypeError, match=r"ConcreteModelItem.__init__\(\) got an unexpected "
-                         r"keyword argument 'foo'"
+        TypeError,
+        match=r"ConcreteModelItem.__init__\(\) got an unexpected "
+        r"keyword argument 'foo'",
     ):
         ConcreteModelItem(foo=7)
     with pytest.raises(
         TypeError,
         match=r"ConcreteModelItem.__init__\(\) got unexpected keyword "
-              r"arguments 'foo', 'bar'",
+        r"arguments 'foo', 'bar'",
     ):
         ConcreteModelItem(foo=7, bar=17)
 

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -45,6 +45,25 @@ def test_model_item_init(attributes):
         assert getattr(model_item, attr) == expected
 
 
+def test_handling_of_bogus_init_params():
+    """
+    Test for sensible error message if wrong param passed.
+
+    See https://github.com/Midnighter/structurizr-python/issues/50.
+    """
+    with pytest.raises(
+        TypeError, match=r"ConcreteModelItem.__init__\(\) got an unexpected "
+                         r"keyword argument 'foo'"
+    ):
+        ConcreteModelItem(foo=7)
+    with pytest.raises(
+        TypeError,
+        match=r"ConcreteModelItem.__init__\(\) got unexpected keyword "
+              r"arguments 'foo', 'bar'",
+    ):
+        ConcreteModelItem(foo=7, bar=17)
+
+
 def test_default_element_tags_order(empty_model: Model):
     """
     Test that the default tags get added in the right order.


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/50
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Added check in `ModelItem` for any unused parameters, and now raises meaningful `TypeError` listing them.

------------------------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS