### PR TITLE
Issue 52 refactor model out of hydrate methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Next Release
 * Fix: Add implied relationships to entities (#42)
 * Fix: Add ``dump()``, ``dumps()`` and ``loads()`` methods to ``Workspace`` (#48)
 * Fix: Add support for DeploymentNodes, ContainerInstances, SoftwareSystemInstances and InfrastructureNodes (#37)
+* Fix: Remove need for Model in hydration methods (#52)
 
 0.1.1 (2020-10-19)
 ------------------

--- a/src/structurizr/mixin/childless_mixin.py
+++ b/src/structurizr/mixin/childless_mixin.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provide a mixin that indicates an element type does not have children."""
+
+
+from typing import Iterable
+
+from ..model.element import Element
+
+
+class ChildlessMixin:
+    """Define a mixin for childless element types."""
+
+    @property
+    def child_elements(self) -> Iterable[Element]:
+        """Return child elements (from `Element.children`)."""
+        return []

--- a/src/structurizr/mixin/model_ref_mixin.py
+++ b/src/structurizr/mixin/model_ref_mixin.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from weakref import ref
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ..model import Model
 
 
@@ -39,6 +39,11 @@ class ModelRefMixin:
     def model(self) -> "Model":
         """Return the referenced model."""
         return self.get_model()
+
+    @property
+    def is_in_model(self) -> bool:
+        """Return whether a model has been set."""
+        return self._model() is not None
 
     def get_model(self) -> "Model":
         """

--- a/src/structurizr/mixin/model_ref_mixin.py
+++ b/src/structurizr/mixin/model_ref_mixin.py
@@ -41,7 +41,7 @@ class ModelRefMixin:
         return self.get_model()
 
     @property
-    def is_in_model(self) -> bool:
+    def has_model(self) -> bool:
         """Return whether a model has been set."""
         return self._model() is not None
 

--- a/src/structurizr/model/component.py
+++ b/src/structurizr/model/component.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Iterable, List, Optional
 
 from pydantic import Field
 
+from ..mixin.childless_mixin import ChildlessMixin
 from .code_element import CodeElement, CodeElementIO
 from .static_structure_element import StaticStructureElement, StaticStructureElementIO
 from .tags import Tags
@@ -58,7 +59,7 @@ class ComponentIO(StaticStructureElementIO):
     size: Optional[int] = None
 
 
-class Component(StaticStructureElement):
+class Component(ChildlessMixin, StaticStructureElement):
     """
     Represent a component.
 

--- a/src/structurizr/model/component.py
+++ b/src/structurizr/model/component.py
@@ -27,7 +27,6 @@ from .tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from .container import Container
-    from .model import Model
 
 
 __all__ = ("Component", "ComponentIO")
@@ -109,9 +108,7 @@ class Component(StaticStructureElement):
         self.tags.add(Tags.COMPONENT)
 
     @classmethod
-    def hydrate(
-        cls, component_io: ComponentIO, container: "Container", model: "Model"
-    ) -> "Component":
+    def hydrate(cls, component_io: ComponentIO, container: "Container") -> "Component":
         """Create and hydrate a new `Component` instance from its IO.
 
         This will also automatically register with the model.
@@ -123,5 +120,4 @@ class Component(StaticStructureElement):
             # TODO: code_elements=map(CodeElement.hydrate, component_io.components),
             size=component_io.size,
         )
-        model += component
         return component

--- a/src/structurizr/model/container.py
+++ b/src/structurizr/model/container.py
@@ -156,7 +156,7 @@ class Container(StaticStructureElement):
                 f"{component.parent}. Cannot add to {self}."
             )
         self._components.add(component)
-        if self.is_in_model:
+        if self.has_model:
             model = self.model
             model += component
         return self

--- a/src/structurizr/model/container.py
+++ b/src/structurizr/model/container.py
@@ -107,6 +107,11 @@ class Container(StaticStructureElement):
         """Return read-only list of child components."""
         return list(self._components)
 
+    @property
+    def child_elements(self) -> Iterable[Component]:
+        """Return child elements (from `Element.children`)."""
+        return self.components
+
     @classmethod
     def hydrate(
         cls,

--- a/src/structurizr/model/container.py
+++ b/src/structurizr/model/container.py
@@ -25,7 +25,6 @@ from .tags import Tags
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .model import Model
     from .software_system import SoftwareSystem
 
 
@@ -117,23 +116,16 @@ class Container(StaticStructureElement):
         cls,
         container_io: ContainerIO,
         software_system: "SoftwareSystem",
-        model: "Model",
     ) -> "Container":
-        """Hydrate a new Container instance from its IO.
-
-        This will also automatically register with the model.
-        """
+        """Hydrate a new Container instance from its IO."""
         container = cls(
             **cls.hydrate_arguments(container_io),
             parent=software_system,
             technology=container_io.technology,
         )
-        model += container
 
         for component_io in container_io.components:
-            component = Component.hydrate(
-                component_io, container=container, model=model
-            )
+            component = Component.hydrate(component_io, container=container)
             container += component
 
         return container
@@ -164,8 +156,9 @@ class Container(StaticStructureElement):
                 f"{component.parent}. Cannot add to {self}."
             )
         self._components.add(component)
-        model = self.model
-        model += component
+        if self.is_in_model:
+            model = self.model
+            model += component
         return self
 
     def get_component_with_name(self, name: str) -> Component:

--- a/src/structurizr/model/container_instance.py
+++ b/src/structurizr/model/container_instance.py
@@ -30,7 +30,6 @@ from .tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from .deployment_node import DeploymentNode
-    from .model import Model
 
 
 __all__ = ("ContainerInstance", "ContainerInstanceIO")
@@ -64,18 +63,16 @@ class ContainerInstance(StaticStructureElementInstance):
     def hydrate(
         cls,
         container_instance_io: ContainerInstanceIO,
-        model: "Model",
+        container: Container,
         parent: "DeploymentNode",
     ) -> "ContainerInstance":
         """Hydrate a new ContainerInstance instance from its IO.
 
         This will also automatically register with the model.
         """
-        container = model.get_element(container_instance_io.container_id)
         instance = cls(
             **cls.hydrate_arguments(container_instance_io),
             container=container,
             parent=parent,
         )
-        model += instance
         return instance

--- a/src/structurizr/model/deployment_node.py
+++ b/src/structurizr/model/deployment_node.py
@@ -22,6 +22,7 @@ from pydantic import Field
 from .container import Container
 from .container_instance import ContainerInstance, ContainerInstanceIO
 from .deployment_element import DeploymentElement, DeploymentElementIO
+from .element import Element
 from .infrastructure_node import InfrastructureNode, InfrastructureNodeIO
 from .software_system import SoftwareSystem
 from .software_system_instance import SoftwareSystemInstance, SoftwareSystemInstanceIO
@@ -117,6 +118,16 @@ class DeploymentNode(DeploymentElement):
     def children(self) -> Iterable["DeploymentNode"]:
         """Return read-only list of child nodes."""
         return list(self._children)
+
+    @property
+    def child_elements(self) -> Iterable[Element]:
+        """Return child elements (from `Element.children`)."""
+        return (
+            self.children
+            + self.container_instances
+            + self.software_system_instances
+            + self.infrastructure_nodes
+        )
 
     @property
     def container_instances(self) -> Iterable[ContainerInstance]:

--- a/src/structurizr/model/deployment_node.py
+++ b/src/structurizr/model/deployment_node.py
@@ -280,7 +280,7 @@ class DeploymentNode(DeploymentElement):
                 f"{node.parent}. Cannot add to {self}."
             )
         self._children.add(node)
-        if self.is_in_model:
+        if self.has_model:
             model = self.model
             model += node
 

--- a/src/structurizr/model/deployment_node.py
+++ b/src/structurizr/model/deployment_node.py
@@ -280,8 +280,9 @@ class DeploymentNode(DeploymentElement):
                 f"{node.parent}. Cannot add to {self}."
             )
         self._children.add(node)
-        model = self.model
-        model += node
+        if self.is_in_model:
+            model = self.model
+            model += node
 
     @classmethod
     def hydrate(
@@ -290,15 +291,11 @@ class DeploymentNode(DeploymentElement):
         model: "Model",
         parent: "DeploymentNode" = None,
     ) -> "DeploymentNode":
-        """Hydrate a new DeploymentNode instance from its IO.
-
-        This will also automatically register with the model.
-        """
+        """Hydrate a new DeploymentNode instance from its IO."""
         node = cls(
             **cls.hydrate_arguments(deployment_node_io),
             parent=parent,
         )
-        model += node
 
         for child_io in deployment_node_io.children:
             child_node = DeploymentNode.hydrate(child_io, model=model, parent=node)
@@ -315,9 +312,7 @@ class DeploymentNode(DeploymentElement):
             node._software_system_instances.add(instance)
 
         for infra_node_io in deployment_node_io.infrastructure_nodes:
-            infra_node = InfrastructureNode.hydrate(
-                infra_node_io, model=model, parent=node
-            )
+            infra_node = InfrastructureNode.hydrate(infra_node_io, parent=node)
             node._infrastructure_nodes.add(infra_node)
 
         return node

--- a/src/structurizr/model/deployment_node.py
+++ b/src/structurizr/model/deployment_node.py
@@ -302,12 +302,16 @@ class DeploymentNode(DeploymentElement):
             node += child_node
 
         for instance_io in deployment_node_io.container_instances:
-            instance = ContainerInstance.hydrate(instance_io, model=model, parent=node)
+            container = model.get_element(instance_io.container_id)
+            instance = ContainerInstance.hydrate(
+                instance_io, container=container, parent=node
+            )
             node._container_instances.add(instance)
 
         for instance_io in deployment_node_io.software_system_instances:
+            system = model.get_element(instance_io.software_system_id)
             instance = SoftwareSystemInstance.hydrate(
-                instance_io, model=model, parent=node
+                instance_io, system=system, parent=node
             )
             node._software_system_instances.add(instance)
 

--- a/src/structurizr/model/element.py
+++ b/src/structurizr/model/element.py
@@ -86,7 +86,7 @@ class Element(ModelRefMixin, ModelItem, ABC):
     @abstractmethod
     def child_elements(self) -> Iterable["Element"]:
         """Return the elements that are children of this one."""
-        ...  # pragma: no cover
+        pass  # pragma: no cover
 
     def get_relationships(self) -> Iterator[Relationship]:
         """Return a Iterator over all relationships involving this element."""

--- a/src/structurizr/model/element.py
+++ b/src/structurizr/model/element.py
@@ -82,6 +82,14 @@ class Element(ModelRefMixin, ModelItem, ABC):
         """Return a string representation of this instance."""
         return f"{type(self).__name__}(id={self.id}, name={self.name})"
 
+    @property
+    def child_elements(self) -> Iterable["Element"]:
+        """Return the elements that are children of this one.
+
+        Subclasses should override this to provide their specific children.
+        """
+        return []
+
     def get_relationships(self) -> Iterator[Relationship]:
         """Return a Iterator over all relationships involving this element."""
         return (

--- a/src/structurizr/model/element.py
+++ b/src/structurizr/model/element.py
@@ -16,7 +16,7 @@
 """Provide a superclass for all model elements."""
 
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Iterable, Iterator, List, Optional
 
 from pydantic import Field, HttpUrl
@@ -83,12 +83,10 @@ class Element(ModelRefMixin, ModelItem, ABC):
         return f"{type(self).__name__}(id={self.id}, name={self.name})"
 
     @property
+    @abstractmethod
     def child_elements(self) -> Iterable["Element"]:
-        """Return the elements that are children of this one.
-
-        Subclasses should override this to provide their specific children.
-        """
-        return []
+        """Return the elements that are children of this one."""
+        ...  # pragma: no cover
 
     def get_relationships(self) -> Iterator[Relationship]:
         """Return a Iterator over all relationships involving this element."""

--- a/src/structurizr/model/infrastructure_node.py
+++ b/src/structurizr/model/infrastructure_node.py
@@ -21,7 +21,6 @@ from .tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from .deployment_node import DeploymentNode
-    from .model import Model
 
 
 __all__ = ("InfrastructureNode", "InfrastructureNodeIO")
@@ -69,17 +68,12 @@ class InfrastructureNode(DeploymentElement):
     def hydrate(
         cls,
         node_io: InfrastructureNodeIO,
-        model: "Model",
         parent: "DeploymentNode",
     ) -> "InfrastructureNode":
-        """Hydrate a new InfrastructureNode instance from its IO.
-
-        This will also automatically register with the model.
-        """
+        """Hydrate a new InfrastructureNode instance from its IO."""
         node = cls(
             **cls.hydrate_arguments(node_io),
             technology=node_io.technology,
             parent=parent,
         )
-        model += node
         return node

--- a/src/structurizr/model/infrastructure_node.py
+++ b/src/structurizr/model/infrastructure_node.py
@@ -15,6 +15,7 @@
 
 from typing import TYPE_CHECKING, Optional
 
+from ..mixin.childless_mixin import ChildlessMixin
 from .deployment_element import DeploymentElement, DeploymentElementIO
 from .tags import Tags
 
@@ -40,7 +41,7 @@ class InfrastructureNodeIO(DeploymentElementIO):
     technology: Optional[str] = ""
 
 
-class InfrastructureNode(DeploymentElement):
+class InfrastructureNode(ChildlessMixin, DeploymentElement):
     """
     Represent an infrastructure node.
 

--- a/src/structurizr/model/model.py
+++ b/src/structurizr/model/model.py
@@ -310,11 +310,8 @@ class Model(AbstractBase):
         """
         if relationship is None:
             relationship = Relationship(**kwargs)
-        # Check
-        if self._add_relationship(relationship, create_implied_relationships):
-            return relationship
-        else:
-            return
+        self._add_relationship(relationship, create_implied_relationships)
+        return relationship
 
     def get_element(self, id: str) -> Optional[Element]:
         """
@@ -373,9 +370,9 @@ class Model(AbstractBase):
 
     def _add_relationship(
         self, relationship: Relationship, create_implied_relationships: bool
-    ) -> bool:
+    ):
         if relationship in self.get_relationships():
-            return True
+            return
         if not relationship.id:
             relationship.id = self._id_generator.generate_id()
         elif relationship.id in self._elements_by_id:
@@ -395,7 +392,6 @@ class Model(AbstractBase):
 
         if create_implied_relationships:
             self.implied_relationship_strategy(relationship)
-        return True
 
     def _add_relationship_to_internal_structures(self, relationship: Relationship):
         self._relationships_by_id[relationship.id] = relationship

--- a/src/structurizr/model/model.py
+++ b/src/structurizr/model/model.py
@@ -153,13 +153,13 @@ class Model(AbstractBase):
         )
 
         for person_io in model_io.people:
-            Person.hydrate(person_io, model=model)
+            model += Person.hydrate(person_io)
 
         for software_system_io in model_io.software_systems:
-            SoftwareSystem.hydrate(software_system_io, model=model)
+            model += SoftwareSystem.hydrate(software_system_io)
 
         for deployment_node_io in model_io.deployment_nodes:
-            DeploymentNode.hydrate(deployment_node_io, model=model)
+            model += DeploymentNode.hydrate(deployment_node_io, model=model)
 
         for element in model.get_elements():
             for relationship in element.relationships:
@@ -368,6 +368,8 @@ class Model(AbstractBase):
         self._elements_by_id[element.id] = element
         element.set_model(self)
         self._id_generator.found(element.id)
+        for child in element.child_elements:
+            self += child
 
     def _add_relationship(
         self, relationship: Relationship, create_implied_relationships: bool

--- a/src/structurizr/model/person.py
+++ b/src/structurizr/model/person.py
@@ -16,7 +16,7 @@
 """Provide a person model."""
 
 
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from pydantic import Field
 
@@ -25,9 +25,6 @@ from .relationship import Relationship
 from .static_structure_element import StaticStructureElement, StaticStructureElementIO
 from .tags import Tags
 
-
-if TYPE_CHECKING:  # pragma: no cover
-    from .model import Model
 
 __all__ = ("PersonIO", "Person")
 
@@ -63,16 +60,12 @@ class Person(StaticStructureElement):
         self.tags.add(Tags.PERSON)
 
     @classmethod
-    def hydrate(cls, person_io: PersonIO, model: "Model") -> "Person":
-        """Create a new person and hydrate from its IO.
-
-        This will also automatically register with the model.
-        """
+    def hydrate(cls, person_io: PersonIO) -> "Person":
+        """Create a new person and hydrate from its IO."""
         person = cls(
             **cls.hydrate_arguments(person_io),
             location=person_io.location,
         )
-        model += person
         return person
 
     def interacts_with(

--- a/src/structurizr/model/person.py
+++ b/src/structurizr/model/person.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from pydantic import Field
 
+from ..mixin.childless_mixin import ChildlessMixin
 from .location import Location
 from .relationship import Relationship
 from .static_structure_element import StaticStructureElement, StaticStructureElementIO
@@ -43,7 +44,7 @@ class PersonIO(StaticStructureElementIO):
     )
 
 
-class Person(StaticStructureElement):
+class Person(ChildlessMixin, StaticStructureElement):
     """
     Represent a person in the C4 model.
 

--- a/src/structurizr/model/software_system.py
+++ b/src/structurizr/model/software_system.py
@@ -110,7 +110,7 @@ class SoftwareSystem(StaticStructureElement):
                 f"{container.parent}. Cannot add to {self}."
             )
         self._containers.add(container)
-        if self.is_in_model:
+        if self.has_model:
             model = self.model
             model += container
         return self

--- a/src/structurizr/model/software_system.py
+++ b/src/structurizr/model/software_system.py
@@ -79,6 +79,11 @@ class SoftwareSystem(StaticStructureElement):
         """Return read-only list of child containers."""
         return list(self._containers)
 
+    @property
+    def child_elements(self) -> Iterable[Container]:
+        """Return child elements (from `Element.children`)."""
+        return self.containers
+
     def add_container(
         self, name: str, description: str = "", technology: str = "", **kwargs
     ) -> Container:

--- a/src/structurizr/model/software_system_instance.py
+++ b/src/structurizr/model/software_system_instance.py
@@ -30,7 +30,6 @@ from .tags import Tags
 
 if TYPE_CHECKING:  # pragma: no cover
     from .deployment_node import DeploymentNode
-    from .model import Model
 
 
 __all__ = ("SoftwareSystemInstance", "SoftwareSystemInstanceIO")
@@ -64,11 +63,10 @@ class SoftwareSystemInstance(StaticStructureElementInstance):
     def hydrate(
         cls,
         system_instance_io: SoftwareSystemInstanceIO,
-        model: "Model",
+        system: SoftwareSystem,
         parent: "DeploymentNode",
     ) -> "SoftwareSystemInstance":
         """Hydrate a new SoftwareSystemInstance instance from its IO."""
-        system = model.get_element(system_instance_io.software_system_id)
         instance = cls(
             **cls.hydrate_arguments(system_instance_io),
             software_system=system,

--- a/src/structurizr/model/software_system_instance.py
+++ b/src/structurizr/model/software_system_instance.py
@@ -67,15 +67,11 @@ class SoftwareSystemInstance(StaticStructureElementInstance):
         model: "Model",
         parent: "DeploymentNode",
     ) -> "SoftwareSystemInstance":
-        """Hydrate a new SoftwareSystemInstance instance from its IO.
-
-        This will also automatically register with the model.
-        """
+        """Hydrate a new SoftwareSystemInstance instance from its IO."""
         system = model.get_element(system_instance_io.software_system_id)
         instance = cls(
             **cls.hydrate_arguments(system_instance_io),
             software_system=system,
             parent=parent,
         )
-        model += instance
         return instance

--- a/src/structurizr/model/static_structure_element_instance.py
+++ b/src/structurizr/model/static_structure_element_instance.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Iterable, List, Optional, Set
 
 from pydantic import Field
 
+from ..mixin.childless_mixin import ChildlessMixin
 from .deployment_element import DeploymentElement, DeploymentElementIO
 from .http_health_check import HTTPHealthCheck, HTTPHealthCheckIO
 from .static_structure_element import StaticStructureElement
@@ -41,7 +42,7 @@ class StaticStructureElementInstanceIO(DeploymentElementIO, ABC):
     health_checks: List[HTTPHealthCheckIO] = Field(default=(), alias="healthChecks")
 
 
-class StaticStructureElementInstance(DeploymentElement, ABC):
+class StaticStructureElementInstance(ChildlessMixin, DeploymentElement, ABC):
     """Define a superclass for all deployment instances."""
 
     def __init__(

--- a/tests/unit/model/test_container.py
+++ b/tests/unit/model/test_container.py
@@ -67,6 +67,13 @@ def test_container_add_component_adds_to_component_list(
     assert component.parent is empty_container
 
 
+def test_container_child_elements_property(model_with_container: MockModel):
+    """Verify children property works."""
+    empty_container = model_with_container.empty_container
+    component = empty_container.add_component(name="Component")
+    assert component in empty_container.child_elements
+
+
 def test_container_add_constructed_component(model_with_container: MockModel):
     """Verify behaviour when adding a newly constructed Container."""
     empty_container = model_with_container.empty_container

--- a/tests/unit/model/test_container_instance.py
+++ b/tests/unit/model/test_container_instance.py
@@ -83,23 +83,13 @@ def test_container_instance_tags(model_with_container):
     assert Tags.CONTAINER_INSTANCE in instance.tags
 
 
-def test_container_instance_hydration_retrieves_container_from_id(model_with_container):
-    """Check that the container instance is retrieved from the model on hydration."""
-    io = ContainerInstanceIO(container_id="19", instance_id=3, environment="Live")
-
-    instance = ContainerInstance.hydrate(io, model_with_container, parent=None)
-
-    assert instance.instance_id == 3
-    assert instance.environment == "Live"
-    assert instance.container is model_with_container.mock_container
-    assert instance.container_id == "19"
-
-
 def test_container_instance_name_is_container_name(model_with_container):
     """Ensure container instance takes its name from its container."""
     io = ContainerInstanceIO(container_id="19", instance_id=3, environment="Live")
 
-    instance = ContainerInstance.hydrate(io, model_with_container, parent=None)
+    instance = ContainerInstance.hydrate(
+        io, model_with_container.mock_container, parent=None
+    )
 
     assert instance.name == "Mock Container"
 
@@ -114,7 +104,9 @@ def test_container_instance_hyrdates_http_health_checks(model_with_container):
         health_checks=[health_check_io],
     )
 
-    instance = ContainerInstance.hydrate(io, model_with_container, parent=None)
+    instance = ContainerInstance.hydrate(
+        io, model_with_container.mock_container, parent=None
+    )
 
     assert len(instance.health_checks) == 1
     assert list(instance.health_checks)[0].name == "name"

--- a/tests/unit/model/test_deployment_node.py
+++ b/tests/unit/model/test_deployment_node.py
@@ -128,7 +128,6 @@ def test_deployment_node_serialization_of_recursive_nodes(model_with_node):
     new_child = new_top_node.children[0]
     assert new_child.name == "child"
     assert new_child.parent is new_top_node
-    assert new_child.model is model_with_node
 
 
 def test_deployment_node_add_container(model_with_node):
@@ -190,7 +189,6 @@ def test_deployment_node_serialising_container(model_with_node):
     instance = node2.container_instances[0]
     assert instance.instance_id == 1
     assert instance.container is container
-    assert instance.model is model_with_node
     assert instance.parent is node2
 
 
@@ -226,7 +224,6 @@ def test_deployment_node_serialising_software_system(model_with_node):
     instance = node2.software_system_instances[0]
     assert instance.instance_id == 1
     assert instance.software_system is system
-    assert instance.model is model_with_node
     assert instance.parent is node2
 
 
@@ -258,5 +255,4 @@ def test_deployment_node_serialising_infrastructure_nodes(model_with_node):
     assert len(node2.infrastructure_nodes) == 1
     infra_node = node2.infrastructure_nodes[0]
     assert infra_node.name == "infraNode"
-    assert infra_node.model is model_with_node
     assert infra_node.parent is node2

--- a/tests/unit/model/test_deployment_node.py
+++ b/tests/unit/model/test_deployment_node.py
@@ -158,15 +158,19 @@ def test_deployment_node_add_with_iadd(model_with_node: MockModel):
 
     node += child_node
     assert child_node in node.children
+    assert child_node in node.child_elements
 
     node += system
     assert node.software_system_instances[0].software_system is system
+    assert node.software_system_instances[0] in node.child_elements
 
     child_node += container
     assert child_node.container_instances[0].container is container
+    assert child_node.container_instances[0] in child_node.child_elements
 
     child_node += infra_node
     assert infra_node in child_node.infrastructure_nodes
+    assert child_node.infrastructure_nodes[0] in child_node.child_elements
 
 
 def test_deployment_node_serialising_container(model_with_node):

--- a/tests/unit/model/test_element.py
+++ b/tests/unit/model/test_element.py
@@ -57,6 +57,12 @@ def test_model_reference():
     assert element.get_model() is model
 
 
+def test_element_child_elements_default():
+    """Ensure that by default, element has no children."""
+    element = ConcreteElement(name="Element")
+    assert element.child_elements == []
+
+
 def test_element_can_only_add_relationship_to_source():
     """Make sure that nothing adds a relationship to the wrong element."""
     element1 = ConcreteElement(name="elt1")

--- a/tests/unit/model/test_element.py
+++ b/tests/unit/model/test_element.py
@@ -18,10 +18,11 @@
 
 import pytest
 
+from structurizr.mixin.childless_mixin import ChildlessMixin
 from structurizr.model.element import Element
 
 
-class ConcreteElement(Element):
+class ConcreteElement(ChildlessMixin, Element):
     """Implement a concrete `Element` class for testing purposes."""
 
     pass

--- a/tests/unit/model/test_infrastructure_node.py
+++ b/tests/unit/model/test_infrastructure_node.py
@@ -65,12 +65,12 @@ def test_infrastructure_node_tags():
     assert Tags.INFRASTRUCTURE_NODE in node.tags
 
 
-def test_infrastructure_node_hydration(empty_model):
+def test_infrastructure_node_hydration():
     """Check hydrating an infrastructure node from its IO."""
     io = InfrastructureNodeIO(name="node1", technology="tech")
     parent = object()
 
-    node = InfrastructureNode.hydrate(io, empty_model, parent=parent)
+    node = InfrastructureNode.hydrate(io, parent=parent)
 
     assert node.name == "node1"
     assert node.technology == "tech"

--- a/tests/unit/model/test_model.py
+++ b/tests/unit/model/test_model.py
@@ -157,6 +157,23 @@ def test_model_cannot_add_two_software_systems_with_same_name(empty_model: Model
         empty_model.add_software_system(name="Bob")
 
 
+def test_model_get_software_system_bad_id(empty_model: Model):
+    """Test that trying to get a system by a non-system ID returns None."""
+    system = empty_model.add_software_system(name="System")
+    container = system.add_container(name="Container")
+
+    assert empty_model.get_software_system_with_id(container.id) is None
+
+
+def test_model_add_element_with_existing_id_raises_error(empty_model: Model):
+    """Test you can't add an element with the same ID as an existing one."""
+    system1 = empty_model.add_software_system(name="System")
+    system2 = SoftwareSystem(name="System2", id=system1.id)
+
+    with pytest.raises(ValueError, match="The element .* has an existing ID"):
+        empty_model += system2
+
+
 def test_model_automatically_adds_child_elements(empty_model: Model):
     """Check that adding a parent element to the model also adds its children."""
     system = SoftwareSystem(name="System")

--- a/tests/unit/model/test_model.py
+++ b/tests/unit/model/test_model.py
@@ -179,6 +179,6 @@ def test_model_automatically_adds_child_elements(empty_model: Model):
     system = SoftwareSystem(name="System")
     container = system.add_container(name="Container")
 
-    assert not container.is_in_model
+    assert not container.has_model
     empty_model += system
-    assert container.is_in_model
+    assert container.has_model

--- a/tests/unit/model/test_model.py
+++ b/tests/unit/model/test_model.py
@@ -165,6 +165,13 @@ def test_model_get_software_system_bad_id(empty_model: Model):
     assert empty_model.get_software_system_with_id(container.id) is None
 
 
+def test_model_add_element_twice_is_ignored(empty_model: Model):
+    """Test you can't add an element with the same ID as an existing one."""
+    system1 = empty_model.add_software_system(name="System")
+    empty_model += system1
+    assert empty_model.software_systems == {system1}
+
+
 def test_model_add_element_with_existing_id_raises_error(empty_model: Model):
     """Test you can't add an element with the same ID as an existing one."""
     system1 = empty_model.add_software_system(name="System")

--- a/tests/unit/model/test_model.py
+++ b/tests/unit/model/test_model.py
@@ -155,3 +155,13 @@ def test_model_cannot_add_two_software_systems_with_same_name(empty_model: Model
         match="A software system with the name 'Bob' already exists in the model.",
     ):
         empty_model.add_software_system(name="Bob")
+
+
+def test_model_automatically_adds_child_elements(empty_model: Model):
+    """Check that adding a parent element to the model also adds its children."""
+    system = SoftwareSystem(name="System")
+    container = system.add_container(name="Container")
+
+    assert not container.is_in_model
+    empty_model += system
+    assert container.is_in_model

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -76,5 +76,5 @@ def test_tag_order_is_preserved_to_and_from_io(empty_model: Model):
     element_io = SoftwareSystemIO.from_orm(element)
     assert element_io.tags == ["Element", "Software System", "tag3", "tag2", "tag1"]
     assert element_io.dict()["tags"] == "Element,Software System,tag3,tag2,tag1"
-    element2 = SoftwareSystem.hydrate(element_io, Model())
+    element2 = SoftwareSystem.hydrate(element_io)
     assert list(element2.tags) == ["Element", "Software System", "tag3", "tag2", "tag1"]

--- a/tests/unit/model/test_software_system.py
+++ b/tests/unit/model/test_software_system.py
@@ -84,6 +84,15 @@ def test_software_system_add_container_adds_to_container_list(
     assert container.parent is empty_system
 
 
+def test_software_system_child_elements_property(
+    model_with_system: MockModel,
+):
+    """Ensure that children propery returns containers."""
+    empty_system = model_with_system.empty_system
+    container = empty_system.add_container(name="Container", description="Description")
+    assert container in empty_system.child_elements
+
+
 def test_software_system_add_constructed_container(model_with_system: MockModel):
     """Verify behaviour when adding a newly constructed Container."""
     empty_system = model_with_system.empty_system

--- a/tests/unit/model/test_software_system.py
+++ b/tests/unit/model/test_software_system.py
@@ -153,7 +153,7 @@ def test_software_system_serialisation(model_with_system: MockModel):
 
     system_io = SoftwareSystemIO.from_orm(empty_system)
 
-    new_system = SoftwareSystem.hydrate(system_io, model_with_system)
+    new_system = SoftwareSystem.hydrate(system_io)
     assert new_system.name == "Sys"
     assert len(new_system.containers) == 1
     container = next(iter(new_system.containers))

--- a/tests/unit/model/test_software_system_instance.py
+++ b/tests/unit/model/test_software_system_instance.py
@@ -86,29 +86,15 @@ def test_software_system_instance_tags(model_with_system):
     assert Tags.SOFTWARE_SYSTEM_INSTANCE in node.tags
 
 
-def test_software_system_instance_hydration_retrieves_software_system_from_id(
-    model_with_system,
-):
-    """Check that the software_system instance is retrieved on hydration."""
-    io = SoftwareSystemInstanceIO(
-        software_system_id="19", instance_id=3, environment="Live"
-    )
-
-    instance = SoftwareSystemInstance.hydrate(io, model_with_system, parent=None)
-
-    assert instance.instance_id == 3
-    assert instance.environment == "Live"
-    assert instance.software_system is model_with_system.mock_system
-    assert instance.software_system_id == "19"
-
-
 def test_software_system_instance_name_is_software_system_name(model_with_system):
     """Ensure software_system instance takes its name from its software system."""
     io = SoftwareSystemInstanceIO(
         software_system_id="19", instance_id=3, environment="Live"
     )
 
-    instance = SoftwareSystemInstance.hydrate(io, model_with_system, parent=None)
+    instance = SoftwareSystemInstance.hydrate(
+        io, model_with_system.mock_system, parent=None
+    )
 
     assert instance.name == "Mock System"
 
@@ -123,7 +109,9 @@ def test_software_system_instance_hyrdates_http_health_checks(model_with_system)
         health_checks=[health_check_io],
     )
 
-    instance = SoftwareSystemInstance.hydrate(io, model_with_system, parent=None)
+    instance = SoftwareSystemInstance.hydrate(
+        io, model_with_system.mock_system, parent=None
+    )
 
     assert len(instance.health_checks) == 1
     assert list(instance.health_checks)[0].name == "name"


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/52
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Refactoring out the need for a `Model` when hydrating classes such as `SoftwareSystem`.  This means that most elements can now be instantiated (explicitly or through hydration) and also have child elements added to them without being in a model and then later added to a model (which will recursively add their children).

Note that `DeploymentNode` still needs the `Model` as the instances that it contains need to look up their containers/systems from the model.