### PR TITLE
Better error messages for unknown initialization keyword arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ History
 
 Next Release
 ------------
+* Fix: Better error on bad ModelItem constructor argument (#50)
 
 0.2.1 (2020-11-27)
 ------------------

--- a/src/structurizr/abstract_base.py
+++ b/src/structurizr/abstract_base.py
@@ -25,6 +25,25 @@ __all__ = ("AbstractBase",)
 class AbstractBase(ABC):
     """Define common business logic through an abstract base class."""
 
+    def __init__(self, **kwargs):
+        """
+        Initialize an abstract base class.
+
+        The AbstractBase class is designed to be the singular root of the entire class
+        hierarchy, similar to `object`, and acts as a guard against unknown keyword
+        arguments. Any keyword arguments not consumed in the hierarchy above cause a
+        `TypeError`.
+
+        """
+        if kwargs:
+            is_plural = len(kwargs) > 1
+            message = "\n    ".join(f"{key}={value}" for key, value in kwargs.items())
+            raise TypeError(
+                f"{type(self).__name__}.__init__() got {'' if is_plural else 'an '}"
+                f"unexpected keyword argument{'s' if is_plural else ''}:\n    {message}"
+            )
+        super().__init__()
+
     def __hash__(self) -> int:
         """Return an integer that represents a unique hash value for this instance."""
         return id(self)

--- a/src/structurizr/abstract_base.py
+++ b/src/structurizr/abstract_base.py
@@ -36,11 +36,14 @@ class AbstractBase(ABC):
 
         """
         if kwargs:
-            is_plural = len(kwargs) > 1
+            phrase = (
+                "unexpected keyword arguments"
+                if len(kwargs) > 1
+                else "an unexpected keyword argument"
+            )
             message = "\n    ".join(f"{key}={value}" for key, value in kwargs.items())
             raise TypeError(
-                f"{type(self).__name__}.__init__() got {'' if is_plural else 'an '}"
-                f"unexpected keyword argument{'s' if is_plural else ''}:\n    {message}"
+                f"{type(self).__name__}.__init__() got {phrase}:\n    {message}"
             )
         super().__init__()
 

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -84,21 +84,7 @@ class ModelItem(AbstractBase, ABC):
         **kwargs,
     ):
         """Initialise a ModelItem instance."""
-        if len(kwargs) > 0:
-            type_name = type(self).__name__
-            args = [f"'{key}'" for key in kwargs.keys()]
-            if len(args) == 1:
-                raise TypeError(
-                    f"{type_name}.__init__() got an unexpected "
-                    f"keyword argument {args[0]}"
-                )
-            else:
-                raise TypeError(
-                    f"{type_name}.__init__() got unexpected "
-                    f"keyword arguments {', '.join(args)}"
-                )
-
-        super().__init__()
+        super().__init__(**kwargs)
         self.id = id
         self.tags = OrderedSet(tags)
         self.properties = dict(properties)

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -84,7 +84,17 @@ class ModelItem(AbstractBase, ABC):
         **kwargs,
     ):
         """Initialise a ModelItem instance."""
-        super().__init__(**kwargs)
+        if len(kwargs) > 0:
+            type_name = type(self).__name__
+            args = [f"'{key}'" for key in kwargs.keys()]
+            if len(args) == 1:
+                raise TypeError(f"{type_name}.__init__() got an unexpected "
+                                f"keyword argument {args[0]}")
+            else:
+                raise TypeError(f"{type_name}.__init__() got unexpected "
+                                f"keyword arguments {', '.join(args)}")
+
+        super().__init__()
         self.id = id
         self.tags = OrderedSet(tags)
         self.properties = dict(properties)

--- a/src/structurizr/model/model_item.py
+++ b/src/structurizr/model/model_item.py
@@ -88,11 +88,15 @@ class ModelItem(AbstractBase, ABC):
             type_name = type(self).__name__
             args = [f"'{key}'" for key in kwargs.keys()]
             if len(args) == 1:
-                raise TypeError(f"{type_name}.__init__() got an unexpected "
-                                f"keyword argument {args[0]}")
+                raise TypeError(
+                    f"{type_name}.__init__() got an unexpected "
+                    f"keyword argument {args[0]}"
+                )
             else:
-                raise TypeError(f"{type_name}.__init__() got unexpected "
-                                f"keyword arguments {', '.join(args)}")
+                raise TypeError(
+                    f"{type_name}.__init__() got unexpected "
+                    f"keyword arguments {', '.join(args)}"
+                )
 
         super().__init__()
         self.id = id

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -52,14 +52,15 @@ def test_handling_of_bogus_init_params():
     See https://github.com/Midnighter/structurizr-python/issues/50.
     """
     with pytest.raises(
-        TypeError, match=r"ConcreteModelItem.__init__\(\) got an unexpected "
-                         r"keyword argument 'foo'"
+        TypeError,
+        match=r"ConcreteModelItem.__init__\(\) got an unexpected "
+        r"keyword argument 'foo'",
     ):
         ConcreteModelItem(foo=7)
     with pytest.raises(
         TypeError,
         match=r"ConcreteModelItem.__init__\(\) got unexpected keyword "
-              r"arguments 'foo', 'bar'",
+        r"arguments 'foo', 'bar'",
     ):
         ConcreteModelItem(foo=7, bar=17)
 

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -45,24 +45,34 @@ def test_model_item_init(attributes):
         assert getattr(model_item, attr) == expected
 
 
-def test_handling_of_bogus_init_params():
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"foo": 7},
+            marks=pytest.mark.raises(
+                exception=TypeError,
+                message="ConcreteModelItem.__init__() got an unexpected keyword "
+                "argument:\n    foo=7",
+            ),
+        ),
+        pytest.param(
+            {"foo": 7, "bar": 17},
+            marks=pytest.mark.raises(
+                exception=TypeError,
+                message="ConcreteModelItem.__init__() got unexpected keyword "
+                "arguments:\n    foo=7\n    bar=17",
+            ),
+        ),
+    ],
+)
+def test_handle_unknown_argument(kwargs: dict):
     """
-    Test for sensible error message if wrong param passed.
+    Test for a sensible error message when unknown keyword arguments are passed.
 
     See https://github.com/Midnighter/structurizr-python/issues/50.
     """
-    with pytest.raises(
-        TypeError,
-        match=r"ConcreteModelItem.__init__\(\) got an unexpected "
-        r"keyword argument 'foo'",
-    ):
-        ConcreteModelItem(foo=7)
-    with pytest.raises(
-        TypeError,
-        match=r"ConcreteModelItem.__init__\(\) got unexpected keyword "
-        r"arguments 'foo', 'bar'",
-    ):
-        ConcreteModelItem(foo=7, bar=17)
+    ConcreteModelItem(**kwargs)
 
 
 def test_default_element_tags_order(empty_model: Model):

--- a/tests/unit/model/test_model_item.py
+++ b/tests/unit/model/test_model_item.py
@@ -45,6 +45,25 @@ def test_model_item_init(attributes):
         assert getattr(model_item, attr) == expected
 
 
+def test_handling_of_bogus_init_params():
+    """
+    Test for sensible error message if wrong param passed.
+
+    See https://github.com/Midnighter/structurizr-python/issues/50.
+    """
+    with pytest.raises(
+        TypeError, match=r"ConcreteModelItem.__init__\(\) got an unexpected "
+                         r"keyword argument 'foo'"
+    ):
+        ConcreteModelItem(foo=7)
+    with pytest.raises(
+        TypeError,
+        match=r"ConcreteModelItem.__init__\(\) got unexpected keyword "
+              r"arguments 'foo', 'bar'",
+    ):
+        ConcreteModelItem(foo=7, bar=17)
+
+
 def test_default_element_tags_order(empty_model: Model):
     """
     Test that the default tags get added in the right order.


### PR DESCRIPTION
* [x] fix #50
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../CHANGELOG.rst)

I couldn't push to your branch (PR #51 addressing #50) so I've made a new branch. This pushes the keyword argument handling down to `AbstractBase` where multiple inheritance should never be an issue. Let me know what you think about this approach @yt-ms 