### PR TITLE
Issue 54: suppress archiving if location is set to None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Next Release
 ------------
 * Fix: Better error on bad ModelItem constructor argument (#50)
+* Fix: Suppress archiving of downloaded workspaces by setting archive location to None (#54)
 
 0.2.1 (2020-11-27)
 ------------------

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -55,7 +55,7 @@ class StructurizrClient:
         user (str): A string identifying the user (e.g. an e-mail address or username).
         agent (str): A string identifying the agent (e.g. 'structurizr-java/1.2.0').
         workspace_archive_location (pathlib.Path): A directory for archiving downloaded
-            workspaces.
+            workspaces, or None to suppress archiving.
 
     """
 
@@ -276,13 +276,14 @@ class StructurizrClient:
 
     def _archive_workspace(self, json: str) -> None:
         """Store the workspace."""
-        location = self._create_archive_filename()
-        logger.debug(
-            f"Archiving workspace {self.workspace_id} to"
-            f" '{self.workspace_archive_location}'."
-        )
-        with gzip.open(location, mode="wt") as handle:
-            handle.write(json)
+        if self.workspace_archive_location is not None:
+            location = self._create_archive_filename()
+            logger.debug(
+                f"Archiving workspace {self.workspace_id} to"
+                f" '{self.workspace_archive_location}'."
+            )
+            with gzip.open(location, mode="wt") as handle:
+                handle.write(json)
 
     def _create_archive_filename(self) -> Path:
         """Generate a filename for a workspace archive."""

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -276,14 +276,15 @@ class StructurizrClient:
 
     def _archive_workspace(self, json: str) -> None:
         """Store the workspace."""
-        if self.workspace_archive_location is not None:
-            location = self._create_archive_filename()
-            logger.debug(
-                f"Archiving workspace {self.workspace_id} to"
-                f" '{self.workspace_archive_location}'."
-            )
-            with gzip.open(location, mode="wt") as handle:
-                handle.write(json)
+        if self.workspace_archive_location is None:
+            return
+        location = self._create_archive_filename()
+        logger.debug(
+            f"Archiving workspace {self.workspace_id} to"
+            f" '{self.workspace_archive_location}'."
+        )
+        with gzip.open(location, mode="wt") as handle:
+            handle.write(json)
 
     def _create_archive_filename(self) -> Path:
         """Generate a filename for a workspace archive."""

--- a/src/structurizr/api/structurizr_client_settings.py
+++ b/src/structurizr/api/structurizr_client_settings.py
@@ -20,6 +20,7 @@ import logging
 from getpass import getuser
 from pathlib import Path
 from socket import getfqdn
+from typing import Optional
 
 
 try:
@@ -98,10 +99,11 @@ class StructurizrClientSettings(BaseSettings):
         env="STRUCTURIZR_AGENT",
         description="A string identifying the agent (e.g. 'structurizr-java/1.2.0').",
     )
-    workspace_archive_location: DirectoryPath = Field(
+    workspace_archive_location: Optional[DirectoryPath] = Field(
         default=Path.cwd(),
         env="STRUCTURIZR_WORKSPACE_ARCHIVE_LOCATION",
-        description="A directory for archiving downloaded workspaces.",
+        description="A directory for archiving downloaded workspaces, or None to "
+        "suppress archiving.",
     )
 
     class Config:

--- a/tests/unit/api/test_structurizr_client.py
+++ b/tests/unit/api/test_structurizr_client.py
@@ -117,6 +117,20 @@ def test_archive_workspace(client, mocker):
     mocked_handle.write.assert_called_once_with('{"mock_key":"mock_value"}')
 
 
+def test_suppressing_archive(mock_settings, mocker):
+    """Test that when the archive location is None then no archive is written."""
+    old_settings = mock_settings._asdict()
+    old_settings["workspace_archive_location"] = None
+    new_mock_settings = MockSettings(**old_settings)
+    client = StructurizrClient(settings=new_mock_settings)
+
+    mocked_open = mocker.mock_open(mock=mocker.Mock(spec_set=GzipFile))
+    mocker.patch("gzip.open", mocked_open)
+
+    client._archive_workspace('{"mock_key":"mock_value"}')
+    assert not mocked_open.called
+
+
 def test_httpx_response_raw_path_behaviour():
     """Make sure that `Response.raw_path` continues to do what we need.
 

--- a/tests/unit/api/test_structurizr_client_settings.py
+++ b/tests/unit/api/test_structurizr_client_settings.py
@@ -137,6 +137,12 @@ def dotenv(tmpdir, monkeypatch, archive_location):
             "api_secret": "ae140655-da7c-4a8d-9467-5a7d9792fca0",
             "workspace_archive_location": ".",
         },
+        {
+            "workspace_id": 19,
+            "api_key": "7f4e4edc-f61c-4ff2-97c9-ea4bc2a7c98c",
+            "api_secret": "ae140655-da7c-4a8d-9467-5a7d9792fca0",
+            "workspace_archive_location": None,
+        },
     ],
 )
 def test_init_from_arguments(attributes: dict):
@@ -145,7 +151,7 @@ def test_init_from_arguments(attributes: dict):
     for attr, expected in attributes.items():
         value = getattr(settings, attr)
         if attr in ("api_key", "api_secret", "workspace_archive_location"):
-            value = str(value)
+            value = None if value is None else str(value)
         assert value == expected
 
 


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/54
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

If `archive_workspace_location` is explicitly set to `None` in the client settings, then this will suppress the client creating archived zip files of each workspace it downloads from the API.

------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.