### PR TITLE
Issue 63: StaticView.add_nearest_neighbours() should not duplicate relationships

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ History
 
 Next Release
 ------------
+* Fix: Don't duplicate relationships if ``add_nearest_neighbours()`` called twice (#63)
 
 0.3.0 (2020-11-29)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Next Release
 ------------
 * Fix: Don't duplicate relationships if ``add_nearest_neighbours()`` called twice (#63)
+* Fix: Support blank diagrams descriptions from the Structurizr UI (#40)
 
 0.3.0 (2020-11-29)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 qa:
 	isort src/structurizr/ tests/ examples/ setup.py
 	black src/structurizr/ tests/ examples/ setup.py
+	flake8 src/structurizr/ tests/ examples/ setup.py
 
 ## Prepare a release by generating the automatic code documentation.
 release:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@
 qa:
 	isort src/structurizr/ tests/ examples/ setup.py
 	black src/structurizr/ tests/ examples/ setup.py
-	flake8 src/structurizr/ tests/ examples/ setup.py
 
 ## Prepare a release by generating the automatic code documentation.
 release:

--- a/examples/big_bank.py
+++ b/examples/big_bank.py
@@ -152,14 +152,16 @@ def create_big_bank_workspace():
     single_page_application.tags.add(web_browser_tag)
     mobile_app = internet_banking_system.add_container(
         "Mobile App",
-        "Provides a limited subset of the Internet banking functionality to customers via their mobile device.",
+        "Provides a limited subset of the Internet banking functionality to "
+        + "customers via their mobile device.",
         "Xamarin",
         id="mobileApp",
     )
     mobile_app.tags.add(mobile_app_tag)
     web_application = internet_banking_system.add_container(
         "Web Application",
-        "Delivers the static content and the Internet banking single page application.",
+        "Delivers the static content and the Internet banking single page "
+        + "application.",
         "Java and Spring MVC",
         id="webApplication",
     )
@@ -171,7 +173,8 @@ def create_big_bank_workspace():
     )
     database = internet_banking_system.add_container(
         "Database",
-        "Stores user registration information, hashed authentication credentials, access logs, etc.",
+        "Stores user registration information, hashed authentication credentials, "
+        + "access logs, etc.",
         "Relational Database Schema",
         id="database",
     )
@@ -188,8 +191,9 @@ def create_big_bank_workspace():
     api_application.uses(email_system, "Sends e-mail using", technology="SMTP")
 
     # components
-    # - for a real-world software system, you would probably want to extract the components using
-    # - static analysis/reflection rather than manually specifying them all
+    # - for a real-world software system, you would probably want to extract the
+    #   components using static analysis/reflection rather than manually specifying
+    #   them all
 
     signin_controller = api_application.add_component(
         name="Sign In Controller",
@@ -211,7 +215,8 @@ def create_big_bank_workspace():
     )
     security_component = api_application.add_component(
         name="Security Component",
-        description="Provides functionality related to signing in, changing passwords, etc.",
+        description="Provides functionality related to signing in, changing passwords, "
+        + "etc.",
         technology="Spring Bean",
         id="securityComponent",
     )
@@ -353,7 +358,8 @@ def create_big_bank_workspace():
     secondary_database_server.tags.add(failover_tag)
     secondary_database = secondary_database_server.add_container(database)
 
-    # # model.Relationships.Where(r=>r.Destination.Equals(secondary_database)).ToList().ForEach(r=>r.tags.add(failover_tag))
+    # model.Relationships.Where(r=>r.Destination.Equals(secondary_database)).ToList()
+    #   .ForEach(r=>r.tags.add(failover_tag))
     data_replication_relationship = primary_database_server.uses(
         secondary_database_server, "Replicates data to"
     )
@@ -400,7 +406,8 @@ def create_big_bank_workspace():
     component_view.add(email_system)
     component_view.paper_size = PaperSize.A5_Landscape
 
-    # systemLandscapeView.AddAnimation(internet_banking_system, customer, mainframe_banking_system, emailSystem)
+    # systemLandscapeView.AddAnimation(internet_banking_system, customer,
+    #   mainframe_banking_system, emailSystem)
     # systemLandscapeView.AddAnimation(atm)
     # systemLandscapeView.AddAnimation(customerServiceStaff, back_office_staff)
 
@@ -418,20 +425,24 @@ def create_big_bank_workspace():
 
     # componentView.AddAnimation(singlePageApplication, mobile_app)
     # componentView.AddAnimation(signinController, securityComponent, database)
-    # componentView.AddAnimation(accountsSummaryController, mainframe_banking_systemFacade, mainframe_banking_system)
+    # componentView.AddAnimation(accountsSummaryController,
+    #   mainframe_banking_systemFacade, mainframe_banking_system)
     # componentView.AddAnimation(resetPasswordController, emailComponent, database)
 
     # # dynamic diagrams and deployment diagrams are not available with the Free Plan
-    # DynamicView dynamicView = views.CreateDynamicView(apiApplication, "SignIn", "Summarises how the sign in feature works in the single-page application.")
+    # DynamicView dynamicView = views.CreateDynamicView(apiApplication, "SignIn",
+    #   "Summarises how the sign in feature works in the single-page application.")
     # dynamicView.Add(singlePageApplication, "Submits credentials to", signinController)
     # dynamicView.Add(signinController, "Calls isAuthenticated() on", securityComponent)
-    # dynamicView.Add(securityComponent, "select * from users where username = ?", database)
+    # dynamicView.Add(securityComponent, "select * from users where username = ?",
+    #   database)
     # dynamicView.PaperSize = PaperSize.A5_Landscape
 
     development_deployment_view = views.create_deployment_view(
         software_system=internet_banking_system,
         key="DevelopmentDeployment",
-        description="An example development deployment scenario for the Internet Banking System.",
+        description="An example development deployment scenario for the Internet "
+        + "Banking System.",
         environment="Development",
     )
     development_deployment_view.add(developer_laptop)
@@ -440,7 +451,8 @@ def create_big_bank_workspace():
     live_deployment_view = views.create_deployment_view(
         software_system=internet_banking_system,
         key="LiveDeployment",
-        description="An example live deployment scenario for the Internet Banking System.",
+        description="An example live deployment scenario for the Internet Banking "
+        + "System.",
         environment="Live",
     )
     live_deployment_view += big_bank_data_center

--- a/examples/big_bank.py
+++ b/examples/big_bank.py
@@ -153,7 +153,7 @@ def create_big_bank_workspace():
     mobile_app = internet_banking_system.add_container(
         "Mobile App",
         "Provides a limited subset of the Internet banking functionality to "
-        + "customers via their mobile device.",
+        "customers via their mobile device.",
         "Xamarin",
         id="mobileApp",
     )

--- a/examples/big_bank.py
+++ b/examples/big_bank.py
@@ -174,7 +174,7 @@ def create_big_bank_workspace():
     database = internet_banking_system.add_container(
         "Database",
         "Stores user registration information, hashed authentication credentials, "
-        + "access logs, etc.",
+        "access logs, etc.",
         "Relational Database Schema",
         id="database",
     )
@@ -216,7 +216,7 @@ def create_big_bank_workspace():
     security_component = api_application.add_component(
         name="Security Component",
         description="Provides functionality related to signing in, changing passwords, "
-        + "etc.",
+        "etc.",
         technology="Spring Bean",
         id="securityComponent",
     )
@@ -442,7 +442,7 @@ def create_big_bank_workspace():
         software_system=internet_banking_system,
         key="DevelopmentDeployment",
         description="An example development deployment scenario for the Internet "
-        + "Banking System.",
+        "Banking System.",
         environment="Development",
     )
     development_deployment_view.add(developer_laptop)
@@ -452,7 +452,7 @@ def create_big_bank_workspace():
         software_system=internet_banking_system,
         key="LiveDeployment",
         description="An example live deployment scenario for the Internet Banking "
-        + "System.",
+        "System.",
         environment="Live",
     )
     live_deployment_view += big_bank_data_center

--- a/examples/big_bank.py
+++ b/examples/big_bank.py
@@ -161,7 +161,7 @@ def create_big_bank_workspace():
     web_application = internet_banking_system.add_container(
         "Web Application",
         "Delivers the static content and the Internet banking single page "
-        + "application.",
+        "application.",
         "Java and Spring MVC",
         id="webApplication",
     )

--- a/examples/financial_risk_system.py
+++ b/examples/financial_risk_system.py
@@ -127,7 +127,10 @@ def main() -> Workspace:
     contextView = views.create_system_context_view(
         software_system=financial_risk_system,
         key="Context",
-        description="An example System Context diagram for the Financial Risk System architecture kata.",
+        description=(
+            "An example System Context diagram for the Financial Risk System "
+            "architecture kata."
+        ),
     )
     contextView.add_all_software_systems()
     contextView.add_all_people()

--- a/src/structurizr/view/static_view.py
+++ b/src/structurizr/view/static_view.py
@@ -72,7 +72,7 @@ class StaticView(View, ABC):
     @abstractmethod
     def add_all_elements(self) -> None:
         """Add all permitted elements from a model to this view."""
-        pass
+        pass  # pragma: no cover
 
     def add(
         self,

--- a/src/structurizr/view/static_view.py
+++ b/src/structurizr/view/static_view.py
@@ -106,7 +106,7 @@ class StaticView(View, ABC):
         element_type: Union[Type[Person], Type[SoftwareSystem], Type[Container]],
     ) -> None:
         """Add all permitted elements from a model to this view."""
-        self._add_element(element, True)
+        self._add_element(element, False)
 
         # TODO(ilaif): @midnighter - Should we move to @property instead
         #  of get_X()? More pythonic.

--- a/src/structurizr/view/view.py
+++ b/src/structurizr/view/view.py
@@ -42,7 +42,7 @@ class ViewIO(BaseModel, ABC):
     """
 
     key: str
-    description: str
+    description: str = ""
     software_system_id: Optional[str] = Field(default=None, alias="softwareSystemId")
     paper_size: Optional[PaperSize] = Field(default=None, alias="paperSize")
     automatic_layout: Optional[AutomaticLayoutIO] = Field(

--- a/src/structurizr/view/view.py
+++ b/src/structurizr/view/view.py
@@ -173,14 +173,23 @@ class View(ViewSetRefMixin, AbstractBase, ABC):
         """Add a single relationship to this view.
 
         Returns:
-            The new view if both the source and destination for the relationship are
-            in this view, else `None`.
+            The new (or existing) view if both the source and destination for the
+            relationship are in this view, else `None`.
         """
         if self.is_element_in_view(relationship.source) and self.is_element_in_view(
             relationship.destination
         ):
-            view = RelationshipView(relationship=relationship)
-            self.relationship_views.add(view)
+            view = next(
+                (
+                    rv
+                    for rv in self.relationship_views
+                    if rv.relationship is relationship
+                ),
+                None,
+            )
+            if not view:
+                view = RelationshipView(relationship=relationship)
+                self.relationship_views.add(view)
             return view
         return None
 

--- a/tests/unit/view/test_static_view.py
+++ b/tests/unit/view/test_static_view.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Ensure the expected behaviour of StaticView."""
+
+
+import pytest
+
+from structurizr.model import Model, Person, SoftwareSystem
+from structurizr.view.static_view import StaticView
+
+
+class DerivedView(StaticView):
+    """Mock class for testing."""
+
+    def add_all_elements(self) -> None:
+        """Stub method because base is abstract."""
+        pass
+
+
+def test_add_nearest_neighbours():
+    """Test basic behaviour of add_nearest_neighbours."""
+    model = Model()
+    sys1 = model.add_software_system(name="System 1")
+    sys2 = model.add_software_system(name="System 2")
+    person = model.add_person(name="Person 1")
+    sys1.uses(sys2)
+    person.uses(sys1)
+
+    # Check neighbours from outbound relationships
+    view = DerivedView(software_system=sys1, description="")
+    view.add_nearest_neighbours(sys1, SoftwareSystem)
+    assert any((elt_view.element is sys1 for elt_view in view.element_views))
+    assert any((elt_view.element is sys2 for elt_view in view.element_views))
+    assert not any((elt_view.element is person for elt_view in view.element_views))
+    assert len(view.relationship_views) == 1
+
+    # Check neighbours from inbound relationships
+    view = DerivedView(software_system=sys1, description="")
+    view.add_nearest_neighbours(sys2, SoftwareSystem)
+    assert any((elt_view.element is sys1 for elt_view in view.element_views))
+    assert any((elt_view.element is sys2 for elt_view in view.element_views))
+    assert not any((elt_view.element is person for elt_view in view.element_views))
+    assert len(view.relationship_views) == 1
+
+
+@pytest.mark.xfail(strict=True)
+def test_add_nearest_neighbours_doesnt_dupe_relationships():
+    """Test relationships aren't duplicated if neighbours added more than once.
+
+    See https://github.com/Midnighter/structurizr-python/issues/63.
+    """
+
+    model = Model()
+    sys1 = model.add_software_system(name="System 1")
+    sys2 = model.add_software_system(name="System 2")
+    sys1.uses(sys2)
+    view = DerivedView(software_system=sys1, description="")
+    view.add_nearest_neighbours(sys1, SoftwareSystem)
+    assert len(view.relationship_views) == 1
+
+    # The next line will currently dupe the relationship
+    view.add_nearest_neighbours(sys1, Person)
+    assert len(view.relationship_views) == 1  # This fails as it's 2

--- a/tests/unit/view/test_static_view.py
+++ b/tests/unit/view/test_static_view.py
@@ -16,8 +16,6 @@
 """Ensure the expected behaviour of StaticView."""
 
 
-import pytest
-
 from structurizr.model import Model, Person, SoftwareSystem
 from structurizr.view.static_view import StaticView
 
@@ -56,13 +54,11 @@ def test_add_nearest_neighbours():
     assert len(view.relationship_views) == 1
 
 
-@pytest.mark.xfail(strict=True)
 def test_add_nearest_neighbours_doesnt_dupe_relationships():
     """Test relationships aren't duplicated if neighbours added more than once.
 
     See https://github.com/Midnighter/structurizr-python/issues/63.
     """
-
     model = Model()
     sys1 = model.add_software_system(name="System 1")
     sys2 = model.add_software_system(name="System 2")
@@ -71,6 +67,6 @@ def test_add_nearest_neighbours_doesnt_dupe_relationships():
     view.add_nearest_neighbours(sys1, SoftwareSystem)
     assert len(view.relationship_views) == 1
 
-    # The next line will currently dupe the relationship
+    # The next line should not add any new relationships
     view.add_nearest_neighbours(sys1, Person)
-    assert len(view.relationship_views) == 1  # This fails as it's 2
+    assert len(view.relationship_views) == 1

--- a/tests/unit/view/test_view.py
+++ b/tests/unit/view/test_view.py
@@ -15,9 +15,10 @@
 
 """Ensure the expected behaviour of View."""
 
+import pytest
 
 from structurizr.model import Model
-from structurizr.view.view import View
+from structurizr.view.view import View, ViewIO
 
 
 class DerivedView(View):
@@ -79,3 +80,22 @@ def test_adding_all_relationships():
     assert len(view.relationship_views) == 2
     assert rel1 in [vr.relationship for vr in view.relationship_views]
     assert rel2 in [vr.relationship for vr in view.relationship_views]
+
+
+@pytest.mark.xfail(strict=True)
+def test_missing_json_description_allowed():
+    """
+    Ensure that missing descriptions in the JSON form are supported.
+
+    Raised as https://github.com/Midnighter/structurizr-python/issues/40, it is
+    permitted through the Structurizr UI to create views with a blank description,
+    which then gets ommitted from the workspace JSON, so this needs to be allowed by
+    the Pydantic validation also.
+    """
+
+    json = """
+    {
+        "key": "System1-SystemContext"
+    }
+    """
+    ViewIO.parse_raw(json)  # Fails as description is missing

--- a/tests/unit/view/test_view.py
+++ b/tests/unit/view/test_view.py
@@ -16,7 +16,7 @@
 """Ensure the expected behaviour of View."""
 
 
-from structurizr.model import Model, SoftwareSystem
+from structurizr.model import Model
 from structurizr.view.view import View
 
 

--- a/tests/unit/view/test_view.py
+++ b/tests/unit/view/test_view.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Ensure the expected behaviour of View."""
+
+
+from structurizr.model import Model, SoftwareSystem
+from structurizr.view.view import View
+
+
+class DerivedView(View):
+    """Mock class for testing."""
+
+    pass
+
+
+def test_add_relationship_doesnt_duplicate():
+    """Test that adding a relationships twice doesn't duplicate it."""
+    model = Model()
+    sys1 = model.add_software_system(name="System 1")
+    sys2 = model.add_software_system(name="System 2")
+    rel = sys1.uses(sys2)
+
+    view = DerivedView(software_system=sys1, description="")
+    view._add_element(sys1, False)
+    view._add_element(sys2, False)
+
+    rel_view1 = view._add_relationship(rel)
+    assert len(view.relationship_views) == 1
+    rel_view2 = view._add_relationship(rel)
+    assert len(view.relationship_views) == 1
+    assert rel_view2 is rel_view1
+
+
+def test_add_relationship_for_element_not_in_view():
+    """Ensures relationships for elements outside the view are ignored."""
+    model = Model()
+    sys1 = model.add_software_system(name="System 1")
+    sys2 = model.add_software_system(name="System 2")
+    rel = sys1.uses(sys2)
+
+    view = DerivedView(software_system=sys1, description="")
+    view._add_element(sys1, False)
+
+    # This relationship should be ignored as sys2 isn't in the view
+    rel_view1 = view._add_relationship(rel)
+    assert rel_view1 is None
+    assert view.relationship_views == set()
+
+
+def test_adding_all_relationships():
+    """Test adding all relationships for elements in the view."""
+    model = Model()
+    sys1 = model.add_software_system(name="System 1")
+    sys2 = model.add_software_system(name="System 2")
+    sys3 = model.add_software_system(name="System 3")
+    rel1 = sys1.uses(sys2)
+    rel2 = sys3.uses(sys1)
+
+    view = DerivedView(software_system=sys1, description="")
+    view._add_element(sys1, False)
+    view._add_element(sys2, False)
+    view._add_element(sys3, False)
+    assert view.relationship_views == set()
+
+    view._add_relationships(sys1)
+    assert len(view.relationship_views) == 2
+    assert rel1 in [vr.relationship for vr in view.relationship_views]
+    assert rel2 in [vr.relationship for vr in view.relationship_views]

--- a/tests/unit/view/test_view.py
+++ b/tests/unit/view/test_view.py
@@ -15,8 +15,6 @@
 
 """Ensure the expected behaviour of View."""
 
-import pytest
-
 from structurizr.model import Model
 from structurizr.view.view import View, ViewIO
 
@@ -82,7 +80,6 @@ def test_adding_all_relationships():
     assert rel2 in [vr.relationship for vr in view.relationship_views]
 
 
-@pytest.mark.xfail(strict=True)
 def test_missing_json_description_allowed():
     """
     Ensure that missing descriptions in the JSON form are supported.
@@ -98,4 +95,5 @@ def test_missing_json_description_allowed():
         "key": "System1-SystemContext"
     }
     """
-    ViewIO.parse_raw(json)  # Fails as description is missing
+    io = ViewIO.parse_raw(json)
+    assert io is not None


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/63, https://github.com/Midnighter/structurizr-python/issues/40
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)


`add_nearest_neighbours()` was calling `_add_element()` with `add_relationships=True` which was resulting in the duplication.  As the relationships are added explicitly based on the type filter, then simply setting this to `False` solves the problem.  Also added a check to `View` to protect against other cases where someone may be unknowingly adding the same relationship twice.

Got caught out by `flake8` yet again, so added this to `make qa` and updated the examples to be compliant.

Also fixed issue 40 whilst in the area, so diagrams with blank descriptions in the Structurizr UI can now be loaded through the Python API.  Not discovered any other similar incompatibilities yet.


--------------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.