### PR TITLE
Preserve externalSoftwareSystemBoundariesVisible flag in JSON

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Release
 ------------
 * Fix: Don't duplicate relationships if ``add_nearest_neighbours()`` called twice (#63)
 * Fix: Support blank diagrams descriptions from the Structurizr UI (#40)
+* Fix: External boundaries visible flag in ContainerView now preserved in JSON (#67)
 
 0.3.0 (2020-11-29)
 ------------------

--- a/src/structurizr/view/container_view.py
+++ b/src/structurizr/view/container_view.py
@@ -39,7 +39,7 @@ class ContainerViewIO(StaticViewIO):
     """
 
     external_software_system_boundary_visible: bool = Field(
-        default=True, alias="externalSoftwareSystemBoundariesVisible"
+        alias="externalSoftwareSystemBoundariesVisible"
     )
 
 

--- a/tests/unit/view/test_container_view.py
+++ b/tests/unit/view/test_container_view.py
@@ -18,7 +18,9 @@ from structurizr.view.container_view import ContainerView, ContainerViewIO
 
 
 def test_external_system_boundary_preserved():
-    """Test the externalSoftwareSystemBoundariesVisible flag appears in the JSON.
+    """
+    Test the externalSoftwareSystemBoundariesVisible flag appears in the JSON.
+    
     Not having this set means that Structurizr assumes it is false (see
     https://github.com/Midnighter/structurizr-python/issues/67).  When exported
     from Structurizr, the flag is present whether true or false, so check that

--- a/tests/unit/view/test_container_view.py
+++ b/tests/unit/view/test_container_view.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Ensure the expected behaviour of DeploymentView."""
+
+
+from structurizr.view.container_view import ContainerView, ContainerViewIO
+
+
+def test_external_system_boundary_preserved():
+    """Test the externalSoftwareSystemBoundariesVisible flag appears in the JSON.
+    Not having this set means that Structurizr assumes it is false (see
+    https://github.com/Midnighter/structurizr-python/issues/67).  When exported
+    from Structurizr, the flag is present whether true or false, so check that
+    is also the case here.
+    """
+    view = ContainerView(
+        key="key",
+        description="description",
+        external_software_system_boundary_visible=True,
+    )
+    json = ContainerViewIO.from_orm(view).json()
+    assert '"externalSoftwareSystemBoundariesVisible": true' in json
+
+    view = ContainerView(
+        key="key",
+        description="description",
+        external_software_system_boundary_visible=False,
+    )
+    json = ContainerViewIO.from_orm(view).json()
+    assert '"externalSoftwareSystemBoundariesVisible": false' in json


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/67
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Removed the default from ContainerViewIO so the flag is now always present in the JSON.

--------------------

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.