### PR TITLE
Issue #62: improve syntax for locking workspaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ History
 Next Release
 ------------
 * Feat: Add support for grouping elements (#72)
+* Feat: Locking workspace in ``with`` block through ``lock()`` method (#62)
 
 0.4.0 (2021-02-05)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Next Release
 ------------
 * Feat: Add support for grouping elements (#72)
 * Feat: Locking workspace in ``with`` block through ``lock()`` method (#62)
+* Fix: On free plans, ignore errors when locking/unlocking workspaces (thanks @maximveksler)
 
 0.4.0 (2021-02-05)
 ------------------

--- a/examples/upload_workspace.py
+++ b/examples/upload_workspace.py
@@ -32,5 +32,5 @@ if __name__ == "__main__":
     settings = StructurizrClientSettings()
     workspace.id = settings.workspace_id
     client = StructurizrClient(settings=settings)
-    with client:
+    with client.lock():
         client.put_workspace(workspace)

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
     httpx ~= 0.16
     importlib_metadata; python_version <'3.8'
     ordered-set
-    pip >= 21.1
     pydantic >= 1.7.1
     python-dotenv
 python_requires = >=3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     httpx ~= 0.16
     importlib_metadata; python_version <'3.8'
     ordered-set
+    pip >= 21.1
     pydantic >= 1.7.1
     python-dotenv
 python_requires = >=3.6

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -20,6 +20,7 @@ import gzip
 import hashlib
 import hmac
 import logging
+import warnings
 from base64 import b64encode
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -100,11 +101,13 @@ class StructurizrClient:
         )
 
     def __enter__(self):
-        """Enter a context by locking the corresponding remote workspace.
-
-        Note: this method is deprecated in favour of lock(), and will be removed in a
-        future relesae.
-        """
+        """Enter a context by locking the corresponding remote workspace."""
+        warnings.warn(
+            "Using the `StructurizrClient` in a context is deprecated since version "
+            "0.4.1 and will be removed in a future release. Please use the "
+            "preferred method `.lock()` instead.",
+            DeprecationWarning,
+        )
         is_successful = self.lock_workspace()
         if not is_successful:
             raise StructurizrClientException(
@@ -114,11 +117,13 @@ class StructurizrClient:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Exit a context by unlocking the corresponding remote workspace.
-
-        Note: this method is deprecated in favour of lock(), and will be removed in a
-        future relesae.
-        """
+        """Exit a context by unlocking the corresponding remote workspace."""
+        warnings.warn(
+            "Using the `StructurizrClient` in a context is deprecated since version "
+            "0.4.1 and will be removed in a future release. Please use the "
+            "preferred method `.lock()` instead.",
+            DeprecationWarning,
+        )
         is_successful = self.unlock_workspace()
         self._client.close()
         if exc_type is None and not is_successful:
@@ -135,7 +140,7 @@ class StructurizrClient:
                 f"Failed to lock the Structurizr workspace {self.workspace_id}."
             )
         try:
-            yield None
+            yield self
         finally:
             is_successful = self.unlock_workspace()
             self._client.close()

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -107,8 +107,8 @@ class StructurizrClient:
         """Enter a context by locking the corresponding remote workspace."""
         warnings.warn(
             "Using the `StructurizrClient` in a context is deprecated since version "
-            "0.4.1 and will be removed in a future release. Please use the "
-            "preferred method `.lock()` instead.",
+            "0.5.0 and will be removed in a future release. Please use the preferred "
+            "method `.lock()` instead.",
             DeprecationWarning,
         )
         is_successful = self.lock_workspace()
@@ -123,8 +123,8 @@ class StructurizrClient:
         """Exit a context by unlocking the corresponding remote workspace."""
         warnings.warn(
             "Using the `StructurizrClient` in a context is deprecated since version "
-            "0.4.1 and will be removed in a future release. Please use the "
-            "preferred method `.lock()` instead.",
+            "0.5.0 and will be removed in a future release. Please use the preferred "
+            "method `.lock()` instead.",
             DeprecationWarning,
         )
         is_successful = self.unlock_workspace()

--- a/src/structurizr/api/structurizr_client.py
+++ b/src/structurizr/api/structurizr_client.py
@@ -230,8 +230,8 @@ class StructurizrClient:
         request = self._client.build_request("PUT", self._lock_url, params=self._params)
         request.headers.update(self._add_headers(request))
         response = self._client.send(request)
-        logger.debug("%r", response.json())
         response.raise_for_status()
+        logger.debug("%r", response.json())
         response = APIResponse.parse_raw(response.text)
         if not response.success:
             logger.error(

--- a/tests/unit/api/test_structurizr_client.py
+++ b/tests/unit/api/test_structurizr_client.py
@@ -359,25 +359,3 @@ def test_failed_lock_on_free_plan_doesnt_attempt_unlock(
         pass
 
     assert len(requests) == 1
-
-
-def test_failed_lock_on_free_plan_with_ignore_off(
-    client: StructurizrClient, mocker: MockerFixture
-):
-    """Check that if ignoring free plan lock failures is disabled then it does fail."""
-
-    def fake_send(request: Request):
-        return Response(
-            200,
-            content='{"success": false, "message": "Cannot lock on free plan"}'.encode(
-                "ascii"
-            ),
-            request=request,
-        )
-
-    mocker.patch.object(client._client, "send", new=fake_send)
-
-    client.ignore_free_plan_locking_errors = False
-    with pytest.raises(StructurizrClientException, match="Failed to lock"):
-        with client.lock():
-            pass

--- a/tests/unit/api/test_structurizr_client.py
+++ b/tests/unit/api/test_structurizr_client.py
@@ -210,3 +210,29 @@ def test_locking_and_unlocking(client: StructurizrClient, mocker: MockerFixture)
     assert requests[0].url.path == "/workspace/19/lock"
     assert requests[1].method == "DELETE"
     assert requests[1].url.path == "/workspace/19/lock"
+
+
+def test_locking_and_unlocking_with_context_manager(
+    client: StructurizrClient, mocker: MockerFixture
+):
+    """Check new-style locking using .lock()."""
+    requests: List[Request] = []
+
+    def fake_send(request: Request):
+        nonlocal requests
+        requests.append(request)
+        return Response(
+            200,
+            content='{"success": true, "message": "OK"}'.encode("ascii"),
+            request=request,
+        )
+
+    mocker.patch.object(client._client, "send", new=fake_send)
+    with client.lock():
+        pass
+
+    assert len(requests) == 2
+    assert requests[0].method == "PUT"
+    assert requests[0].url.path == "/workspace/19/lock"
+    assert requests[1].method == "DELETE"
+    assert requests[1].url.path == "/workspace/19/lock"

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ commands=
 
 [testenv:safety]
 deps=
+    pip >= 21.1
     safety
 commands=
     safety check --full-report


### PR DESCRIPTION
* [X] fix #(issue number)
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Added `lock()` method to `ClientWorkspace` to use for `with` blocks in favour of using the client directly.  For the moment, the old way is still there but we should remove in a future release.

On free plans, workspace locking is not supported, so ignore lock failures (credits to [@maximveksler](https://github.com/maximveksler)).

-------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.