### PR TITLE
Add support for grouping elements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ History
 
 Next Release
 ------------
+* Feat: Add support for grouping elements (#72)
 
 0.4.0 (2021-02-05)
 ------------------

--- a/src/structurizr/model/groupable_element.py
+++ b/src/structurizr/model/groupable_element.py
@@ -1,0 +1,56 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Provide a superclass for all elements that can be included in a group."""
+
+
+from abc import ABC
+from typing import Optional
+
+from .element import Element, ElementIO
+
+
+__all__ = ("GroupableElementIO", "GroupableElement")
+
+
+class GroupableElementIO(ElementIO, ABC):
+    """
+    Define a superclass for all elements that can be included in a group.
+
+    Attributes:
+        group (str): The name of thegroup in which this element should be included.
+    """
+
+    group: Optional[str] = ""
+
+
+class GroupableElement(Element, ABC):
+    """
+    Define a superclass for all elements that can be included in a group.
+
+    Attributes:
+        group (str): The name of thegroup in which this element should be included.
+    """
+
+    def __init__(self, *, group: str = "", **kwargs):
+        """Initialise a GroupableElement."""
+        super().__init__(**kwargs)
+        self.group = group
+
+    @classmethod
+    def hydrate_arguments(cls, io: GroupableElementIO) -> dict:
+        """Hydrate an ElementIO into the constructor arguments for Element."""
+        return {
+            **super().hydrate_arguments(io),
+            "group": io.group,
+        }

--- a/src/structurizr/model/groupable_element.py
+++ b/src/structurizr/model/groupable_element.py
@@ -28,10 +28,11 @@ class GroupableElementIO(ElementIO, ABC):
     Define a superclass for all elements that can be included in a group.
 
     Attributes:
-        group (str): The name of thegroup in which this element should be included.
+        group (str): The name of thegroup in which this element should be included, or
+            None if no group.
     """
 
-    group: Optional[str] = ""
+    group: Optional[str]
 
 
 class GroupableElement(Element, ABC):
@@ -39,12 +40,14 @@ class GroupableElement(Element, ABC):
     Define a superclass for all elements that can be included in a group.
 
     Attributes:
-        group (str): The name of thegroup in which this element should be included.
+        group (str): The name of thegroup in which this element should be included, or
+            None if no group.
     """
 
-    def __init__(self, *, group: str = "", **kwargs):
+    def __init__(self, *, group: Optional[str] = None, **kwargs):
         """Initialise a GroupableElement."""
         super().__init__(**kwargs)
+        group = group.strip() or None if group else None
         self.group = group
 
     @classmethod

--- a/src/structurizr/model/static_structure_element.py
+++ b/src/structurizr/model/static_structure_element.py
@@ -19,7 +19,8 @@
 from abc import ABC
 from typing import TYPE_CHECKING, Optional
 
-from .element import Element, ElementIO
+from .element import Element
+from .groupable_element import GroupableElement, GroupableElementIO
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -29,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
 __all__ = ("StaticStructureElementIO", "StaticStructureElement")
 
 
-class StaticStructureElementIO(ElementIO, ABC):
+class StaticStructureElementIO(GroupableElementIO, ABC):
     """
     Define a superclass for all static structure model elements.
 
@@ -41,7 +42,7 @@ class StaticStructureElementIO(ElementIO, ABC):
     pass
 
 
-class StaticStructureElement(Element, ABC):
+class StaticStructureElement(GroupableElement, ABC):
     """
     Define a superclass for all static structure model elements.
 

--- a/tests/integration/data/workspace_definition/Grouping.json
+++ b/tests/integration/data/workspace_definition/Grouping.json
@@ -1,0 +1,252 @@
+{
+    "id" : 0,
+    "name" : "Grouping",
+    "description" : "Based on https://github.com/structurizr/dsl/blob/master/examples/groups.dsl",
+    "properties" : {
+      "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7CiAgICAgICAgZ3JvdXAgIkNvbnN1bWVycyAtIEdyb3VwIDEiIHsKICAgICAgICAgICAgY29uc3VtZXJBID0gc29mdHdhcmVTeXN0ZW0gIkNvbnN1bWVyIEEiCiAgICAgICAgICAgIGNvbnN1bWVyQiA9IHNvZnR3YXJlU3lzdGVtICJDb25zdW1lciBCIgogICAgICAgIH0KICAgICAgICBncm91cCAiQ29uc3VtZXJzIC0gR3JvdXAgMiIgewogICAgICAgICAgICBjb25zdW1lckMgPSBzb2Z0d2FyZVN5c3RlbSAiQ29uc3VtZXIgQyIKICAgICAgICAgICAgY29uc3VtZXJEID0gc29mdHdhcmVTeXN0ZW0gIkNvbnN1bWVyIEQiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJTb2Z0d2FyZSBTeXN0ZW0iICJNeSBzb2Z0d2FyZSBzeXN0ZW0uIiB7CiAgICAgICAgICAgIGdyb3VwICJTZXJ2aWNlIDEiIHsKICAgICAgICAgICAgICAgIHNlcnZpY2UxRGF0YWJhc2UgPSBjb250YWluZXIgIlNlcnZpY2UgMSBEYXRhYmFzZSIKICAgICAgICAgICAgICAgIHNlcnZpY2UxQXBpID0gY29udGFpbmVyICJTZXJ2aWNlIDEgQVBJIgogICAgICAgICAgICB9CiAgICAgICAgICAgIGdyb3VwICJTZXJ2aWNlIDIiIHsKICAgICAgICAgICAgICAgIHNlcnZpY2UyRGF0YWJhc2UgPSBjb250YWluZXIgIlNlcnZpY2UgMiBEYXRhYmFzZSIKICAgICAgICAgICAgICAgIHNlcnZpY2UyQXBpID0gY29udGFpbmVyICJTZXJ2aWNlIDIgQVBJIgogICAgICAgICAgICB9CiAgICAgICAgfQoKICAgICAgICBjb25zdW1lckEgLT4gc2VydmljZTFBcGkgIlVzZXMiCiAgICAgICAgY29uc3VtZXJCIC0+IHNlcnZpY2UxQXBpICJVc2VzIgogICAgICAgIGNvbnN1bWVyQyAtPiBzZXJ2aWNlMUFwaSAiVXNlcyIKICAgICAgICBjb25zdW1lckQgLT4gc2VydmljZTFBcGkgIlVzZXMiCgogICAgICAgIHNlcnZpY2UxQXBpIC0+IHNlcnZpY2UxRGF0YWJhc2UgIlJlYWRzIGZyb20gYW5kIHdyaXRlcyB0byIKICAgICAgICBzZXJ2aWNlMkFwaSAtPiBzZXJ2aWNlMkRhdGFiYXNlICJSZWFkcyBmcm9tIGFuZCB3cml0ZXMgdG8iCiAgICAgICAgc2VydmljZTFBcGkgLT4gc2VydmljZTJBcGkgIlVzZXMiCiAgICB9CgogICAgdmlld3MgewogICAgICAgIHN5c3RlbUNvbnRleHQgc29mdHdhcmVTeXN0ZW0gIlN5c3RlbUNvbnRleHQiIHsKICAgICAgICAgICAgaW5jbHVkZSAqCiAgICAgICAgICAgIGF1dG9MYXlvdXQKICAgICAgICB9CgogICAgICAgIGNvbnRhaW5lciBzb2Z0d2FyZVN5c3RlbSAiQ29udGFpbmVycyIgewogICAgICAgICAgICBpbmNsdWRlICoKICAgICAgICAgICAgYXV0b2xheW91dAogICAgICAgIH0KCiAgICAgICAgc3R5bGVzIHsKICAgICAgICAgICAgZWxlbWVudCAiUGVyc29uIiB7CiAgICAgICAgICAgICAgICBzaGFwZSBwZXJzb24KICAgICAgICAgICAgfQogICAgICAgIH0KICAgIH0KICAgIAp9Cg=="
+    },
+    "configuration" : { },
+    "model" : {
+      "softwareSystems" : [ {
+        "id" : "1",
+        "tags" : "Element,Software System",
+        "name" : "Consumer A",
+        "relationships" : [ {
+          "id" : "10",
+          "tags" : "Relationship",
+          "sourceId" : "1",
+          "destinationId" : "7",
+          "description" : "Uses"
+        }, {
+          "id" : "11",
+          "tags" : "Relationship",
+          "sourceId" : "1",
+          "destinationId" : "5",
+          "description" : "Uses"
+        } ],
+        "group" : "Consumers - Group 1",
+        "location" : "Unspecified"
+      }, {
+        "id" : "2",
+        "tags" : "Element,Software System",
+        "name" : "Consumer B",
+        "relationships" : [ {
+          "id" : "12",
+          "tags" : "Relationship",
+          "sourceId" : "2",
+          "destinationId" : "7",
+          "description" : "Uses"
+        }, {
+          "id" : "13",
+          "tags" : "Relationship",
+          "sourceId" : "2",
+          "destinationId" : "5",
+          "description" : "Uses"
+        } ],
+        "group" : "Consumers - Group 1",
+        "location" : "Unspecified"
+      }, {
+        "id" : "3",
+        "tags" : "Element,Software System",
+        "name" : "Consumer C",
+        "relationships" : [ {
+          "id" : "14",
+          "tags" : "Relationship",
+          "sourceId" : "3",
+          "destinationId" : "7",
+          "description" : "Uses"
+        }, {
+          "id" : "15",
+          "tags" : "Relationship",
+          "sourceId" : "3",
+          "destinationId" : "5",
+          "description" : "Uses"
+        } ],
+        "group" : "Consumers - Group 2",
+        "location" : "Unspecified"
+      }, {
+        "id" : "4",
+        "tags" : "Element,Software System",
+        "name" : "Consumer D",
+        "relationships" : [ {
+          "id" : "16",
+          "tags" : "Relationship",
+          "sourceId" : "4",
+          "destinationId" : "7",
+          "description" : "Uses"
+        }, {
+          "id" : "17",
+          "tags" : "Relationship",
+          "sourceId" : "4",
+          "destinationId" : "5",
+          "description" : "Uses"
+        } ],
+        "group" : "Consumers - Group 2",
+        "location" : "Unspecified"
+      }, {
+        "id" : "5",
+        "tags" : "Element,Software System",
+        "name" : "Software System",
+        "description" : "My software system.",
+        "location" : "Unspecified",
+        "containers" : [ {
+          "id" : "6",
+          "tags" : "Element,Container",
+          "name" : "Service 1 Database",
+          "group" : "Service 1"
+        }, {
+          "id" : "9",
+          "tags" : "Element,Container",
+          "name" : "Service 2 API",
+          "relationships" : [ {
+            "id" : "19",
+            "tags" : "Relationship",
+            "sourceId" : "9",
+            "destinationId" : "8",
+            "description" : "Reads from and writes to"
+          } ],
+          "group" : "Service 2"
+        }, {
+          "id" : "7",
+          "tags" : "Element,Container",
+          "name" : "Service 1 API",
+          "relationships" : [ {
+            "id" : "18",
+            "tags" : "Relationship",
+            "sourceId" : "7",
+            "destinationId" : "6",
+            "description" : "Reads from and writes to"
+          }, {
+            "id" : "20",
+            "tags" : "Relationship",
+            "sourceId" : "7",
+            "destinationId" : "9",
+            "description" : "Uses"
+          } ],
+          "group" : "Service 1"
+        }, {
+          "id" : "8",
+          "tags" : "Element,Container",
+          "name" : "Service 2 Database",
+          "group" : "Service 2"
+        } ]
+      } ]
+    },
+    "documentation" : { },
+    "views" : {
+      "systemContextViews" : [ {
+        "softwareSystemId" : "5",
+        "key" : "SystemContext",
+        "automaticLayout" : {
+          "implementation" : "Graphviz",
+          "rankDirection" : "TopBottom",
+          "rankSeparation" : 300,
+          "nodeSeparation" : 300,
+          "edgeSeparation" : 0,
+          "vertices" : false
+        },
+        "enterpriseBoundaryVisible" : true,
+        "elements" : [ {
+          "id" : "1",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "2",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "3",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "4",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "5",
+          "x" : 0,
+          "y" : 0
+        } ],
+        "relationships" : [ {
+          "id" : "17"
+        }, {
+          "id" : "15"
+        }, {
+          "id" : "13"
+        }, {
+          "id" : "11"
+        } ]
+      } ],
+      "containerViews" : [ {
+        "softwareSystemId" : "5",
+        "key" : "Containers",
+        "automaticLayout" : {
+          "implementation" : "Graphviz",
+          "rankDirection" : "TopBottom",
+          "rankSeparation" : 300,
+          "nodeSeparation" : 300,
+          "edgeSeparation" : 0,
+          "vertices" : false
+        },
+        "externalSoftwareSystemBoundariesVisible" : true,
+        "elements" : [ {
+          "id" : "1",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "2",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "3",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "4",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "6",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "7",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "8",
+          "x" : 0,
+          "y" : 0
+        }, {
+          "id" : "9",
+          "x" : 0,
+          "y" : 0
+        } ],
+        "relationships" : [ {
+          "id" : "18"
+        }, {
+          "id" : "16"
+        }, {
+          "id" : "14"
+        }, {
+          "id" : "12"
+        }, {
+          "id" : "20"
+        }, {
+          "id" : "10"
+        }, {
+          "id" : "19"
+        } ]
+      } ],
+      "configuration" : {
+        "branding" : { },
+        "styles" : {
+          "elements" : [ {
+            "tag" : "Person",
+            "shape" : "Person"
+          } ]
+        },
+        "terminology" : { }
+      }
+    }
+  }

--- a/tests/integration/test_grouping.py
+++ b/tests/integration/test_grouping.py
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ensure grouping works with example workspace."""
+
+from pathlib import Path
+
+from structurizr import Workspace
+
+
+DEFINITIONS = Path(__file__).parent / "data" / "workspace_definition"
+
+
+def test_loading_workspace_with_groups():
+    """Check loading an example workspace with groupings defined."""
+    path = DEFINITIONS / "Grouping.json"
+
+    workspace = Workspace.load(path)
+    consumer_a = workspace.model.get_element("1")
+    consumer_d = workspace.model.get_element("4")
+    assert consumer_a.name == "Consumer A"
+    assert consumer_a.group == "Consumers - Group 1"
+    assert consumer_d.name == "Consumer D"
+    assert consumer_d.group == "Consumers - Group 2"
+
+    service_2_api = workspace.model.get_element("9")
+    assert service_2_api.name == "Service 2 API"
+    assert service_2_api.group == "Service 2"

--- a/tests/unit/model/test_groupable_element.py
+++ b/tests/unit/model/test_groupable_element.py
@@ -23,6 +23,15 @@ class ConcreteElement(ChildlessMixin, GroupableElement):
     pass
 
 
+def test_group_name_normalisation():
+    """Test that empty group names are normalised to None."""
+    assert ConcreteElement(name="Name").group is None
+    assert ConcreteElement(name="Name", group=None).group is None
+    assert ConcreteElement(name="Name", group="").group is None
+    assert ConcreteElement(name="Name", group=" ").group is None
+    assert ConcreteElement(name="Name", group=" g1 ").group == "g1"
+
+
 def test_group_in_json():
     """Test the group field is output to JSON."""
     element = ConcreteElement(name="Name", group="Group 1")

--- a/tests/unit/model/test_groupable_element.py
+++ b/tests/unit/model/test_groupable_element.py
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Ensure the expected behaviour of GroupableElement."""
+
+from structurizr.mixin.childless_mixin import ChildlessMixin
+from structurizr.model.groupable_element import GroupableElement, GroupableElementIO
+
+
+class ConcreteElement(ChildlessMixin, GroupableElement):
+    """Implement a concrete `GroupableElement` class for testing purposes."""
+
+    pass
+
+
+def test_group_in_json():
+    """Test the group field is output to JSON."""
+    element = ConcreteElement(name="Name", group="Group 1")
+    io = GroupableElementIO.from_orm(element)
+    assert '"group": "Group 1"' in io.json()
+
+
+def test_group_omitted_from_json_if_empty():
+    """Test the group field is not output if empty."""
+    element = ConcreteElement(name="Name")
+    io = GroupableElementIO.from_orm(element)
+    assert '"group"' not in io.json()
+
+
+def test_hydration():
+    """Test hydration picks up the group field."""
+    element = ConcreteElement(name="Name", group="Group 1")
+    io = GroupableElementIO.from_orm(element)
+    d = GroupableElement.hydrate_arguments(io)
+    assert d["group"] == "Group 1"

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ commands=
 
 [testenv:safety]
 deps=
-    pip >= 21.1
     safety
 commands=
     safety check --full-report

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ commands=
 
 [testenv:safety]
 deps=
+    pip >= 21.1
     safety
 commands=
     safety check --full-report


### PR DESCRIPTION
* [X] fix https://github.com/Midnighter/structurizr-python/issues/72
* [X] description of feature/fix
* [X] tests added/passed
* [X] add an entry to the [next release](../CHANGELOG.rst)

Structurizr now supports grouping elements to provide more structure (e.g. Containers within a System).  This change adds a `group` property to such elements via a `GroupableElement` supertype, in line with the equivalent Java implementation.

----

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.