### PR TITLE
refactor: combine all views in ViewSet into a single dictionary

### DIFF
--- a/src/structurizr/view/view_set.py
+++ b/src/structurizr/view/view_set.py
@@ -17,7 +17,7 @@
 
 
 from itertools import chain
-from typing import TYPE_CHECKING, Iterable, List, Optional
+from typing import TYPE_CHECKING, Iterable, List, Optional, TypeVar
 
 from pydantic import Field
 
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
 
 
 __all__ = ("ViewSet", "ViewSetIO")
+
+T = TypeVar("T")
 
 
 class ViewSetIO(BaseModel):
@@ -379,5 +381,5 @@ class ViewSet(ModelRefMixin, AbstractBase):
         if key in self._views:
             raise ValueError(f"View already exists in workspace with key '{key}'.")
 
-    def _get_typed_views(self, klass: "T") -> Iterable["T"]:
+    def _get_typed_views(self, klass: T) -> Iterable[T]:
         return (view for view in self._views.values() if isinstance(view, klass))

--- a/src/structurizr/view/view_set.py
+++ b/src/structurizr/view/view_set.py
@@ -107,49 +107,37 @@ class ViewSet(ModelRefMixin, AbstractBase):
     @property
     def system_landscape_views(self) -> Iterable[SystemLandscapeView]:
         """Return the SystemLandscapeViews in this ViewSet."""
-        return (
-            view
-            for view in self._views.values()
-            if isinstance(view, SystemLandscapeView)
-        )
-
+        return self._get_typed_views(SystemLandscapeView)
+        
     @property
     def system_context_views(self) -> Iterable[SystemContextView]:
         """Return the SystemContextViews in this ViewSet."""
-        return (
-            view for view in self._views.values() if isinstance(view, SystemContextView)
-        )
+        return self._get_typed_views(SystemContextView)
 
     @property
     def container_views(self) -> Iterable[ContainerView]:
         """Return the ContainerViews in this ViewSet."""
-        return (
-            view for view in self._views.values() if isinstance(view, ContainerView)
-        )
+        return self._get_typed_views(ContainerView)
 
     @property
     def component_views(self) -> Iterable[ComponentView]:
         """Return the CompoentViews in this ViewSet."""
-        return (
-            view for view in self._views.values() if isinstance(view, ComponentView)
-        )
+        return self._get_typed_views(ComponentView)
 
     @property
     def deployment_views(self) -> Iterable[DeploymentView]:
         """Return the DeploymentViews in this ViewSet."""
-        return (
-            view for view in self._views.values() if isinstance(view, DeploymentView)
-        )
+        return self._get_typed_views(DeploymentView)
 
     @property
     def dynamic_views(self) -> Iterable[DynamicView]:
         """Return the DynamicViews in this ViewSet."""
-        return (view for view in self._views.values() if isinstance(view, DynamicView))
+        return self._get_typed_views(DynamicView)
 
     @property
     def filtered_views(self) -> Iterable[FilteredView]:
         """Return the FilteredViews in this ViewSet."""
-        return (view for view in self._views.values() if isinstance(view, FilteredView))
+        return self._get_typed_views(FilteredView)
 
     @property
     def views(self) -> Iterable[AbstractView]:
@@ -390,3 +378,10 @@ class ViewSet(ModelRefMixin, AbstractBase):
             raise ValueError("A key must be specified.")
         if key in self._views:
             raise ValueError(f"View already exists in workspace with key '{key}'.")
+
+    def _get_typed_views(self, klass: "T") -> Iterable["T"]:
+        return (
+            view
+            for view in self._views.values()
+            if isinstance(view, klass)
+        )

--- a/src/structurizr/view/view_set.py
+++ b/src/structurizr/view/view_set.py
@@ -371,10 +371,7 @@ class ViewSet(ModelRefMixin, AbstractBase):
 
     def __getitem__(self, key: str) -> AbstractView:
         """Return the view with the given key or raise a KeyError."""
-        result = self._views.get(key)
-        if not result:
-            raise KeyError(f"No view with key '{key}' in ViewSet")
-        return result
+        return self._views[key]
 
     def copy_layout_information_from(self, source: "ViewSet") -> None:
         """Copy all the layout information from a source ViewSet."""

--- a/src/structurizr/view/view_set.py
+++ b/src/structurizr/view/view_set.py
@@ -152,7 +152,7 @@ class ViewSet(ModelRefMixin, AbstractBase):
         return (view for view in self._views.values() if isinstance(view, FilteredView))
 
     @property
-    def all_views(self) -> Iterable[AbstractView]:
+    def views(self) -> Iterable[AbstractView]:
         """Return all the views in this ViewSet."""
         return self._views.values()
 
@@ -379,7 +379,7 @@ class ViewSet(ModelRefMixin, AbstractBase):
     def copy_layout_information_from(self, source: "ViewSet") -> None:
         """Copy all the layout information from a source ViewSet."""
 
-        for source_view in source.all_views:
+        for source_view in source.views:
             destination_view = self.get_view(source_view.key)
             if (
                 destination_view

--- a/src/structurizr/view/view_set.py
+++ b/src/structurizr/view/view_set.py
@@ -108,7 +108,7 @@ class ViewSet(ModelRefMixin, AbstractBase):
     def system_landscape_views(self) -> Iterable[SystemLandscapeView]:
         """Return the SystemLandscapeViews in this ViewSet."""
         return self._get_typed_views(SystemLandscapeView)
-        
+
     @property
     def system_context_views(self) -> Iterable[SystemContextView]:
         """Return the SystemContextViews in this ViewSet."""
@@ -380,8 +380,4 @@ class ViewSet(ModelRefMixin, AbstractBase):
             raise ValueError(f"View already exists in workspace with key '{key}'.")
 
     def _get_typed_views(self, klass: "T") -> Iterable["T"]:
-        return (
-            view
-            for view in self._views.values()
-            if isinstance(view, klass)
-        )
+        return (view for view in self._views.values() if isinstance(view, klass))

--- a/src/structurizr/view/view_set.py
+++ b/src/structurizr/view/view_set.py
@@ -391,5 +391,5 @@ class ViewSet(ModelRefMixin, AbstractBase):
     def _ensure_key_is_specific_and_unique(self, key: str) -> None:
         if key is None or key == "":
             raise ValueError("A key must be specified.")
-        if self.get_view(key) is not None:
+        if key in self._views:
             raise ValueError(f"View already exists in workspace with key '{key}'.")

--- a/tests/unit/view/test_view_set.py
+++ b/tests/unit/view/test_view_set.py
@@ -125,7 +125,7 @@ def test_getting_view_by_key(empty_viewset):
     assert viewset.get_view("container1") is container_view
     assert viewset.get_view("bogus") is None
     assert viewset["container1"] is container_view
-    with pytest.raises(KeyError, match="No view with key"):
+    with pytest.raises(KeyError):
         viewset["bogus"]
 
 

--- a/tests/unit/view/test_view_set.py
+++ b/tests/unit/view/test_view_set.py
@@ -12,6 +12,8 @@
 
 """Ensure the correct behaviour of ViewSet."""
 
+from typing import Iterable
+
 import pytest
 
 from structurizr.model.model import Model
@@ -37,7 +39,7 @@ def test_view_set_construction(empty_model):
     """Test constructing a new view set."""
     viewset = ViewSet(model=empty_model)
     assert viewset.model is empty_model
-    assert viewset.dynamic_views == set()
+    assert count(viewset.dynamic_views) == 0
 
 
 def test_adding_dynamic_view(empty_model):
@@ -58,7 +60,7 @@ def test_dynamic_view_hydrated(empty_viewset):
     io = ViewSetIO.from_orm(viewset)
 
     new_viewset = ViewSet.hydrate(io, viewset.model)
-    assert len(new_viewset.dynamic_views) == 1
+    assert count(new_viewset.dynamic_views) == 1
     view = list(new_viewset.dynamic_views)[0]
     assert view.description == "dynamic"
     assert view.element is system1
@@ -105,7 +107,7 @@ def test_filtered_view_hydrated(empty_viewset):
     io = ViewSetIO.from_orm(viewset)
 
     new_viewset = ViewSet.hydrate(io, viewset.model)
-    assert len(new_viewset.filtered_views) == 1
+    assert count(new_viewset.filtered_views) == 1
     view = list(new_viewset.filtered_views)[0]
     assert view.description == "filtered"
     assert isinstance(view.view, ContainerView)
@@ -159,3 +161,8 @@ def test_duplicate_key_raises_error(empty_viewset):
         viewset.create_container_view(
             key="container1", description="container", software_system=system1
         )
+
+
+def count(iterable: Iterable) -> int:
+    """Count items in an iterable, as len doesn't work on generators."""
+    return sum(1 for x in iterable)


### PR DESCRIPTION
This should not have any external impact, but refactors `ViewSet` to combine all the views into a single dictionary so we can key it by the view key.  This simplifies a number of methods which had very repetitive logic per view type.

----------------

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE Apache License v.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.